### PR TITLE
잡다한 버그 해결

### DIFF
--- a/content.js
+++ b/content.js
@@ -1784,7 +1784,7 @@ function translate_StoryText(stext, jsonFile) {
     stext = stext.split('"').join("'");
     stext = stext.replace(/&nbsp;/g, ' ');
     stext = stext.replace(/\s+/g, " ");
-
+    
     if (sex == 0) {
         if (stext.includes(userName))
             if (curLanugage == 'Japanese')
@@ -1830,6 +1830,9 @@ function translate_StoryText(stext, jsonFile) {
             PrintLog('no translation');
             return '';
         }
+    } else {
+        PrintLog('no text');
+        return '';
     }
 }
 

--- a/options.js
+++ b/options.js
@@ -29,7 +29,9 @@ function restore_options() {
     // Use default value extractMode = true.
     chrome.storage.local.get(['verboseMode', 'origin', 'imageswap', 'battleobserver', 'userFont', 'nonTransText'], function(items) {
         document.getElementById('isVerbose').checked = items.verboseMode;
-        document.getElementById('origintext').value = items.origin;
+        if(items.origin){
+            document.getElementById('origintext').value = items.origin;
+        }
         document.getElementById('doImageSwap').checked = items.imageswap;
         document.getElementById('doBattleTranslation').checked = items.battleobserver;
         document.getElementById('fontaddr').value = items.userFont;


### PR DESCRIPTION
### DB 경로에 undefined 값 들어있을 경우 문제 해결

처음 확장 프로그램 깔고 [상세설정] 버튼 눌르면 DB경로에 undefined 값이 들어가있음.

그러고서 바로 상세설정 창을 닫고 나오면 undefined 경로를 참조하는 에러 로그가 개발자 도구에 남음. 

그 부분 해결


### 1장 1에피소드에서 처음 선택지 나올때 비이의 텍스트가 undefined로 출력되는 문제 해결

stext가 undefined일 경우 그냥 공백 문자 돌려주는 것으로 해결.
