### PR TITLE
팝업창의 원문 내용 일부분에 장소명이 있을경우 장소명 부분만 번역시켜버려 원문을 손상시키는 현상 해결.

### DIFF
--- a/content.js
+++ b/content.js
@@ -493,7 +493,6 @@ function replaceUserName() {
 
     if (userName == '') {
         userName = node.attributes[3].value;
-        console.log(userName);
         if (userName == '' && SceneCodeFromURL().includes('tutorial')) {
             if (sex == 0) {
                 if (language == 'Japanese')
@@ -507,8 +506,6 @@ function replaceUserName() {
                     userName = generalConfig.defaultNameFemale_en.substring(1, generalConfig.defaultNameFemale_en.length - 1);
             }
         }
-
-        console.log(userName);
     }
 
     sceneFullInfo.some(function (scene) {
@@ -1846,27 +1843,20 @@ function translate_StoryText(stext, jsonFile) {
         되있는 경우도 있어서 일치하지않음. 이런 문제 해결하기 위해 DB 원문의 [ジータ]을 userName 후처리 
         결과물과 동일하게 되게끔 [グラン]으로 변경하는 후처리 작업을 수행.
     */
-    console.log('username:',userName);
-    console.log('targetdefaultname:',targetDefaultName);
+   
     if (targetDefaultName.length > 0) {
         for (var i = 0; i < sceneData.length; i++) {
             if (sceneData[i].Origin.includes(generalConfig.defaultNameMale_jp)) {
                 sceneData[i].Origin = sceneData[i].Origin.split(generalConfig.defaultNameMale_jp).join(targetDefaultName);
-                console.log(sceneData[i].Origin);
             } else if (sceneData[i].Origin.includes(generalConfig.defaultNameMale_en)) {
                 sceneData[i].Origin = sceneData[i].Origin.split(generalConfig.defaultNameMale_en).join(targetDefaultName);
-                console.log(sceneData[i].Origin);
             } else if (sceneData[i].Origin.includes(generalConfig.defaultNameFemale_jp)) {
                 sceneData[i].Origin = sceneData[i].Origin.split(generalConfig.defaultNameFemale_jp).join(targetDefaultName);
-                console.log(sceneData[i].Origin);
             } else if (sceneData[i].Origin.includes(generalConfig.defaultNameFemale_en)) {
                 sceneData[i].Origin = sceneData[i].Origin.split(generalConfig.defaultNameFemale_en).join(targetDefaultName);
-                console.log(sceneData[i].Origin);
             }
-            
         }
     }
-    console.log('origin:',stext);
     
     for (var i = 0; i < sceneData.length; i++) {
         if (!sceneData[i].Origin)
@@ -2064,7 +2054,6 @@ function GetTranslatedText(node, csv) {
                 userName = doc.getElementsByClassName('cnt-quest-scene')[0].attributes[3].value;
 
                 if (userName == '' && SceneCodeFromURL().includes('tutorial')) {
-                    console.log('bb');
                     if (sex == 0) {
                         if (language == 'Japanese')
                             userName = generalConfig.defaultNameMale_jp.substring(1, generalConfig.defaultNameMale_jp.length - 1);
@@ -2077,7 +2066,6 @@ function GetTranslatedText(node, csv) {
                             userName = generalConfig.defaultNameFemale_en.substring(1, generalConfig.defaultNameFemale_en.length - 1);
                     }
                 }
-                console.log(userName);
             }
             if (userName != "") {
                 if (textInput.includes(userName)) {

--- a/content.js
+++ b/content.js
@@ -287,7 +287,7 @@ function PushCSV_BattleText(request) {
 
         if (battleText.battle_condition) {
             if (battleText.battle_condition.body) {
-                
+
                 if ((battleText.battle_condition.body == copyText)) {
                     skip = true;
                 }
@@ -484,7 +484,7 @@ function replaceUserName() {
         userName = node.attributes[3].value;
 
     sceneFullInfo.some(function (scene) {
-        if(userName != ''){
+        if (userName != '') {
             if (scene.Origin != '') {
                 if (sex == 0) {
                     if (language == 'Japanese')
@@ -1780,30 +1780,30 @@ function translate_StoryText(stext, jsonFile) {
         }
         tmpIndex++;
     });
-	
+
     var curLanugage = doc.title == 'Granblue Fantasy' ? 'English' : 'Japanese';
     stext = stext.replace(/(\r\n|\n|\r)/gm, '').trim();
     stext = stext.split('"').join("'");
     stext = stext.replace(/&nbsp;/g, ' ');
     stext = stext.replace(/\s+/g, " ");
-    
-	if( userName.length > 0){
-		if (sex == 0) {
-			if (stext.includes(userName))
-				if (curLanugage == 'Japanese')
-					stext = stext.split(userName).join(generalConfig.defaultNameMale_jp);
-				else if (curLanugage == 'English')
-				stext = stext.split(userName).join(generalConfig.defaultNameMale_en);
-		} else if (sex == 1) {
-			if (stext.includes(userName))
-				if (curLanugage == 'Japanese')
-					stext = stext.split(userName).join(generalConfig.defaultNameFemale_jp);		
-				else if (curLanugage == 'English')
-					stext = stext.split(userName).join(generalConfig.defaultNameFemale_en);
-		}
-	}
-	
-	for (var i = 0; i < sceneData.length; i++) {
+
+    if (userName.length > 0) {
+        if (sex == 0) {
+            if (stext.includes(userName))
+                if (curLanugage == 'Japanese')
+                    stext = stext.split(userName).join(generalConfig.defaultNameMale_jp);
+                else if (curLanugage == 'English')
+                stext = stext.split(userName).join(generalConfig.defaultNameMale_en);
+        } else if (sex == 1) {
+            if (stext.includes(userName))
+                if (curLanugage == 'Japanese')
+                    stext = stext.split(userName).join(generalConfig.defaultNameFemale_jp);
+                else if (curLanugage == 'English')
+                stext = stext.split(userName).join(generalConfig.defaultNameFemale_en);
+        }
+    }
+
+    for (var i = 0; i < sceneData.length; i++) {
         if (!sceneData[i].Origin)
             continue;
         if (stext.length == sceneData[i].Origin.length) {
@@ -1944,7 +1944,8 @@ function GetTranslatedText(node, csv) {
             textInput.includes('a class') ||
             isNaN(textInput) == false || // Only number
             isNaN(textInput.replace('/', '')) == false || // number / number
-            node.className.includes('txt-atk')
+            node.className.includes('txt-atk') ||
+            node.className.includes('scene-font-place')
         )
             passOrNot = false;
 
@@ -2055,6 +2056,7 @@ function GetTranslatedStoryText(node, csv) {
         var language = doc.title == 'Granblue Fantasy' ? 'English' : 'Japanese';
 
         PrintLog(`GetTranslatedStoryText - className: ${node.className}, text: ${textInput}`);
+
         translatedText = translate_StoryText(textInput, csv);
         if (!translatedText) return;
 
@@ -2069,9 +2071,6 @@ function GetTranslatedStoryText(node, csv) {
         }
         PrintLog(`GetTranslatedStoryText - traslated text: ${translatedText}`);
         if (translatedText.length > 0) {
-            /* 한 글자씩 출력되는 연출을 사용할 경우 나중에 한 글자씩 텍스트창에 출력되는 부분을
-            화면에서 가려버리기 위한 코드*/
-            //translatedText +='<br><br><br><br><br>';
             node.innerHTML = translatedText;
             if (node.className.includes('prt-pop-synopsis')) return;
 
@@ -2082,6 +2081,8 @@ function GetTranslatedStoryText(node, csv) {
                 }
                 if (textContents.innerHTML == '') translatedText = '';
                 textContents.innerHTML = translatedText;
+                /* 사용자가 auto-text 기능 사용 중일 경우 텍스트창에 출력되는 더러운 효과들을
+            화면에서 가려버리기 위한 코드*/
                 textContents.innerHTML += '<br><br><br><br><br>';
             }
         }
@@ -2242,7 +2243,7 @@ function GetTranslatedImageDIV(node, csv) {
 
 function SceneCodeFromURL() {
     var scenecode = '';
-	
+
     if ((doc.URL.includes('play_view/') || doc.URL.includes('play_view_event/')) && !doc.URL.includes('scene_')) {
         if (doc.URL.includes('play_view/')) {
             scenecode = doc.URL.slice(doc.URL.indexOf('play_view/'));
@@ -2260,16 +2261,16 @@ function SceneCodeFromURL() {
         scenecode = doc.URL.slice(doc.URL.indexOf('scene_'));
         scenecode = scenecode.split('/')[0];
     }
-	if (doc.URL.includes('/#tutorial/')){
-        if(doc.URL.includes('/#tutorial/4'))
+    if (doc.URL.includes('/#tutorial/')) {
+        if (doc.URL.includes('/#tutorial/4'))
             scenecode = 'scene_tutorial00';
-        else if(doc.URL.includes('/#tutorial/6'))
+        else if (doc.URL.includes('/#tutorial/6'))
             scenecode = 'scene_tutorial01';
-        else if(doc.URL.includes('/#tutorial/8'))
+        else if (doc.URL.includes('/#tutorial/8'))
             scenecode = 'scene_tutorial02';
-        else if(doc.URL.includes('/#tutorial/12'))
+        else if (doc.URL.includes('/#tutorial/12'))
             scenecode = 'scene_tutorial03';
-	}
+    }
 
     return scenecode;
 }
@@ -2332,11 +2333,6 @@ var sceneObserver = new MutationObserver(function (mutations) {
                 }
             }
 
-            //misc 텍스트를 가져오는 경우 빼고 스토리 텍스트,스토리 이름은 F12를 누르고 새로고침하는 순간
-            //전부 추출되버리니 여기서의 exMode는 기능을 잃어버림.
-            //if (exMode) {
-            //    PushCSV(textName, cNames);
-            //}
             if (transMode) {
                 sceneObserver.disconnect();
                 if (nameNode) {
@@ -2352,9 +2348,9 @@ var sceneObserver = new MutationObserver(function (mutations) {
             ObserveSceneText();
             return true;
         }
-		if (mutation.target.className.includes('txt-message')) {
-                GetTranslatedStoryText(mutation.target, questJson);
-		}
+        if (mutation.target.className.includes('txt-message')) {
+            GetTranslatedStoryText(mutation.target, questJson);
+        }
     });
 });
 
@@ -2365,9 +2361,9 @@ var archiveObserver = new MutationObserver(function (mutations) {
             if (
                 !mutation.target.className.includes('txt-message') &&
                 !mutation.target.className.includes('txt-character-name')
-            )
+            ) {
                 walkDownTree(mutation.target, GetTranslatedText, archiveJson);
-
+            }
         }
     });
     ObserverArchive();
@@ -2391,14 +2387,11 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
 var PopObserver = new MutationObserver(function (mutations) {
     PopObserver.disconnect();
     mutations.forEach(mutation => {
-        if (mutation.target.className.includes('pop-synopsis pop-show')) {
-            GetTranslatedStoryText(
-                doc.getElementsByClassName('prt-pop-synopsis')[0],
-                questJson
-            );
+        if (mutation.target.className.includes('pop-synopsis')) {
+            GetTranslatedStoryText(doc.getElementsByClassName('prt-pop-synopsis')[0], questJson);
+        } else {
+            walkDownTree(mutation.target, GetTranslatedText, archiveJson);
         }
-
-        walkDownTree(mutation.target, GetTranslatedText, archiveJson);
 
         if (doImageSwap) {
             walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
@@ -2436,7 +2429,7 @@ var BattleImageObserver = new MutationObserver(function (mutations) {
 // Queue for each observers
 async function ObserveSceneText() {
     var oText = doc.getElementsByClassName('prt-log-display')[0];
-	var txtMessageNode = doc.getElementsByClassName('prt-message-area')[0];
+    var txtMessageNode = doc.getElementsByClassName('prt-message-area')[0];
     if (!oText || !txtMessageNode) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
@@ -2450,7 +2443,7 @@ async function ObserveSceneText() {
         doc.URL.includes('tutorial')
     ) {
         sceneObserver.observe(oText, config);
-		sceneObserver.observe(txtMessageNode, config);
+        sceneObserver.observe(txtMessageNode, config);
     }
 }
 
@@ -2548,7 +2541,7 @@ async function ObserverBattle() {
         window.setTimeout(ObserverBattle, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid') || doc.URL.includes('/#tutorial/')/* for tutorial page */) {
+    if (doc.URL.includes('#raid') || doc.URL.includes('/#tutorial/') /* for tutorial page */ ) {
         // In battle window, try to use 'white list' to get 
 
         var battleInfo1 = doc.querySelectorAll('[class^="prt-command-chara"]');

--- a/devtools.js
+++ b/devtools.js
@@ -49,9 +49,9 @@ var requestListener = async function (req) {
 				});
 			} else if (req.request.url.includes('start.json') ||
 				req.request.url.includes('normal_attack_result.json') ||
-				req.request.url.includes('ability_result.json')) {
-					
-				req.response.headers.some(function (item) {
+				req.request.url.includes('ability_result.json') ||
+				req.request.url.includes('tutorial')) {
+					req.response.headers.some(function (item) {
 					if (item.value == 'application/json') {
 						req.getContent(function (item) {
 							var obj = JSON.parse(item);


### PR DESCRIPTION
버그 발생 지점 : 루리아노트 - 메인 0장 - 여행의 시작 - 스킵 버튼 눌렀을 때 뜨는 줄거리 요약 창 

버그 내용 : 원문에 장소명이 포함될경우 원문에서 장소명 글자만 번역하여 원문을 손상시켜버림. 그래서 줄거리 요약창이 번역 안됨.
