### PR TITLE
archiveObserver 퍼포먼스 향상

### DIFF
--- a/content.js
+++ b/content.js
@@ -2558,13 +2558,6 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            archiveObserver.disconnect();
-            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);

--- a/content.js
+++ b/content.js
@@ -2452,14 +2452,20 @@ var sceneObserver = new MutationObserver(function (mutations) {
 var archiveObserver = new MutationObserver(function (mutations) {
     archiveObserver.disconnect();
     mutations.forEach(mutation => {
-            if (mutation.target) {
-                if (
-                    !mutation.target.className.includes('txt-message') &&
-                    !mutation.target.className.includes('txt-character-name')
-                ) {
-                    walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+        if (mutation.target) {
+            if (
+                !mutation.target.className.includes('txt-message') &&
+                !mutation.target.className.includes('txt-character-name')
+            ) {
+                if (mutation.target.className == 'contents') {
+                    //mutation 감지되는 노드중에 contents의 부모 노드인 wrapper 노드가 감지가 안됨.
+                    //그래서 contents 노드가 감지될때 부모 노드 wrapper를 번역하게함. 퍼포먼스 영향 없었음.
+                    walkDownTree(doc.getElementById('wrapper'), GetTranslatedText, archiveJson);
+                    return;
                 }
+                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
+        }
     });
     ObserverArchive();
 });
@@ -2558,7 +2564,7 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
@@ -2710,7 +2716,7 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
@@ -2726,7 +2732,7 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);

--- a/content.js
+++ b/content.js
@@ -2452,18 +2452,17 @@ var sceneObserver = new MutationObserver(function (mutations) {
 var archiveObserver = new MutationObserver(function (mutations) {
     archiveObserver.disconnect();
     mutations.forEach(mutation => {
-        if (mutation.target) {
-            if (
-                !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name')
-            ) {
-                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+            if (mutation.target) {
+                if (
+                    !mutation.target.className.includes('txt-message') &&
+                    !mutation.target.className.includes('txt-character-name')
+                ) {
+                    walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+                }
             }
-        }
     });
     ObserverArchive();
 });
-/*
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
     ImageObserver.disconnect();
@@ -2484,27 +2483,6 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
             if (doImageSwap && mutation.target.className) {
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
             }
-        }
-    });
-    ObserverImageDIV();
-});*/
-
-var ImageObserver = new MutationObserver(function (mutations) {
-    // PrintLog(mutations);
-    ImageObserver.disconnect();
-    mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-        }
-    });
-    ObserverImage();
-});
-var ImageObserverDIV = new MutationObserver(function (mutations) {
-    // PrintLog(mutations);
-    ImageObserverDIV.disconnect();
-    mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
         }
     });
     ObserverImageDIV();
@@ -2581,11 +2559,16 @@ async function ObserverArchive() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             archiveObserver.disconnect();
             window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     archiveObserver.observe(oText, config);
 }
@@ -2735,11 +2718,16 @@ async function ObserverImage() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImage, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserver.observe(allElements, config_image);
 }
@@ -2751,12 +2739,17 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+    if (doBattleTrans ) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserverDIV.observe(allElements, config_image);
 }

--- a/content.js
+++ b/content.js
@@ -2710,16 +2710,10 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImage, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
     ImageObserver.observe(allElements, config_image);

--- a/content.js
+++ b/content.js
@@ -2463,8 +2463,35 @@ var archiveObserver = new MutationObserver(function (mutations) {
     });
     ObserverArchive();
 });
+/*
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserver.disconnect();
+    mutations.forEach(mutation => {
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
+            }
+        }
+    });
+    ObserverImage();
+});
+var ImageObserverDIV = new MutationObserver(function (mutations) {
+    // PrintLog(mutations);
+    ImageObserverDIV.disconnect();
+    mutations.forEach(mutation => {
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+            }
+        }
+    });
+    ObserverImageDIV();
+});*/
+
+var ImageObserver = new MutationObserver(function (mutations) {
+    // PrintLog(mutations);
+    ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap && mutation.target.className) {
             walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
@@ -2474,6 +2501,7 @@ var ImageObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap && mutation.target.className) {
             walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
@@ -2545,7 +2573,6 @@ async function ObserveSceneText() {
 }
 
 async function ObserverArchive() {
-    // var oText = doc.getElementById('loading');
     var oText = doc.getElementById('wrapper');
     if (!oText) {
         //The node we need does not exist yet.

--- a/content.js
+++ b/content.js
@@ -2726,16 +2726,10 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans ) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
         return;
     }
     ImageObserverDIV.observe(allElements, config_image);

--- a/content.js
+++ b/content.js
@@ -1719,7 +1719,7 @@ async function InitList() {
         ObserverList = [
             ObserveSceneText(),
             ObserverArchive(),
-            ObserverPop(),
+            //ObserverPop(),
             ObserverStorySelectTexts()
         ];
         if (doImageSwap) ObserverList.push(ObserverImageDIV(), ObserverImage());

--- a/content.js
+++ b/content.js
@@ -104,7 +104,7 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
 });
 
 var config = {
-    attributes: true,
+    //attributes: true,
     childList: true,
     subtree: true,
     characterData: true
@@ -2278,7 +2278,7 @@ function GetTranslatedImageDIV(node, csv) {
             imageStyle = imageStyleCompute;
         if (UseComputeAfter)
             imageStyle = imageStyleComputeAfter;
-        if (!imageStyle)  return;
+        if (!imageStyle) return;
         if (textInput.includes(generalConfig.origin)) return;
         if (!imageStyle.includes('png') ||
             imageStyle.includes('/ui/') ||
@@ -2449,9 +2449,7 @@ var archiveObserver = new MutationObserver(function (mutations) {
         if (mutation.target) {
             if (
                 !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name') &&
-                !mutation.target.className.includes('wrapper') &&
-                !mutation.target.className.includes('contents')
+                !mutation.target.className.includes('txt-character-name')
             ) {
                 walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
@@ -2464,7 +2462,7 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
+            if (mutation.target.className &&
                 mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
@@ -2479,10 +2477,10 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
-                mutation.target.className == 'contents' || 
+            if (mutation.target.className &&
+                mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
-                    
+
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
             }
 
@@ -2512,8 +2510,8 @@ var BattleObserver = new MutationObserver(function (mutations) {
     mutations.forEach(mutation => {
         walkDownTree(mutation.target, GetTranslatedText, archiveJson);
         GetTranslatedBattleText(mutation.target, battleJson);
-        
-        if(doImageSwap)
+
+        if (doImageSwap)
             walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
     });
     ObserverBattle();
@@ -2521,7 +2519,7 @@ var BattleObserver = new MutationObserver(function (mutations) {
 
 var BattleImageObserver = new MutationObserver(function (mutations) {
     BattleImageObserver.disconnect();
-    mutations.forEach(mutation => {	
+    mutations.forEach(mutation => {
         walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
 
         var btn_recovery = doc.querySelectorAll('[class^="btn-temporary"]');
@@ -2562,20 +2560,11 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-        return;
-    }
-    if (
-        doc.URL.includes('archive') ||
-        doc.URL.includes('scene') ||
-        doc.URL.includes('story') ||
-        doc.URL.includes('tutorial')
-    ) {
-        ObserverPop();
-        archiveObserver.observe(oText, config);
-        ObserveSceneText();
-        ObserverStorySelectTexts();
+    if (!doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            archiveObserver.disconnect();
+            return;
+        }
     }
 
     archiveObserver.observe(oText, config);
@@ -2677,26 +2666,26 @@ async function ObserverBattle() {
         }
         var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
         if (battleInfo_btn) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
         }
-        
+
         var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
         if (battleInfo_subbtn) {
             walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
         }
         var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
         if (battleInfo_contrib) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
         }
-        
+
         var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
         if (multilog_overlayer) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(multilog_overlayer, BattleImageObserver, config);
         }
-        
+
         var popDIV = doc.getElementById('pop');
         if (popDIV) {
             PopObserver.observe(popDIV, config);

--- a/content.js
+++ b/content.js
@@ -109,6 +109,12 @@ var config = {
     subtree: true,
     characterData: true
 };
+var config_image = {
+    attributes: true,
+    //childList: true,
+    subtree: true,
+    //characterData: true
+};
 var config_simple = {
     attributes: true,
 };
@@ -2250,7 +2256,7 @@ function GetTranslatedImage(node, csv) {
         )
             return;
         PrintLog(`Send Image URL:${imageInput}`);
-        if (transMode)
+        if (transMode && doImageSwap)
             translatedText = GetTranslatedImageURL(imageInput, csv);
         if (translatedText.length > 0) {
             // When it founds the translated text
@@ -2459,36 +2465,23 @@ var archiveObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-    ImageObserver.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            // }
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
         }
     });
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-
-    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-
-                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            // }
-
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
         }
     });
-
     ObserverImageDIV();
 });
+
 var PopObserver = new MutationObserver(function (mutations) {
     PopObserver.disconnect();
     mutations.forEach(mutation => {
@@ -2560,13 +2553,13 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (!doBattleTrans) {
+    if (doBattleTrans) {
         if (doc.URL.includes('#raid')) {
             archiveObserver.disconnect();
+            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
     }
-
     archiveObserver.observe(oText, config);
 }
 
@@ -2707,37 +2700,38 @@ async function ObserverBattle() {
     }
 }
 async function ObserverImage() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImage, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImage, generalConfig.refreshRate);
+            return;
+        }
     }
-    ImageObserver.observe(allElements, config);
-    ImageObserver.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserver.observe(allElements, config_image);
 }
 async function ObserverImageDIV() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+            return;
+        }
     }
-
-    ImageObserverDIV.observe(allElements, config);
-    ImageObserverDIV.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserverDIV.observe(allElements, config_image);
 }
 
 const main = async () => {

--- a/content.js
+++ b/content.js
@@ -2462,11 +2462,11 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            }
+            // }
         }
     });
     ObserverImage();
@@ -2477,12 +2477,12 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
 
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            }
+            // }
 
         }
     });

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2141,13 +2141,6 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            archiveObserver.disconnect();
-            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2047,18 +2047,24 @@ var archiveObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserver.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
+            }
         }
     });
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+            }
         }
     });
     ObserverImageDIV();

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2034,14 +2034,14 @@ var sceneObserver = new MutationObserver(function (mutations) {
 var archiveObserver = new MutationObserver(function (mutations) {
     archiveObserver.disconnect();
     mutations.forEach(mutation => {
-        if (mutation.target) {
-            if (
-                !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name')
-            ) {
-                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+            if (mutation.target) {
+                if (
+                    !mutation.target.className.includes('txt-message') &&
+                    !mutation.target.className.includes('txt-character-name')
+                ) {
+                    walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+                }
             }
-        }
     });
     ObserverArchive();
 });
@@ -2142,11 +2142,16 @@ async function ObserverArchive() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             archiveObserver.disconnect();
             window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     archiveObserver.observe(oText, config);
 }
@@ -2296,11 +2301,16 @@ async function ObserverImage() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImage, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserver.observe(allElements, config_image);
 }
@@ -2312,12 +2322,17 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+    if (doBattleTrans ) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserverDIV.observe(allElements, config_image);
 }

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2293,16 +2293,10 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImage, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
     ImageObserver.observe(allElements, config_image);

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2044,11 +2044,11 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            }
+            // }
         }
     });
     ObserverImage();
@@ -2059,12 +2059,12 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
 
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            }
+            // }
 
         }
     });

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -2309,16 +2309,10 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans ) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
         return;
     }
     ImageObserverDIV.observe(allElements, config_image);

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -41,6 +41,12 @@ var config = {
     subtree: true,
     characterData: true
 };
+var config_image = {
+    attributes: true,
+    //childList: true,
+    subtree: true,
+    //characterData: true
+};
 var config_simple = {
     attributes: true,
 };
@@ -1859,7 +1865,7 @@ function GetTranslatedImage(node, csv) {
         )
             return;
         PrintLog(`Send Image URL:${imageInput}`);
-        if (transMode)
+        if (transMode && doImageSwap)
             translatedText = GetTranslatedImageURL(imageInput, csv);
         if (translatedText.length > 0) {
             // When it founds the translated text
@@ -2041,36 +2047,23 @@ var archiveObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-    ImageObserver.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            // }
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
         }
     });
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-
-    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-
-                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            // }
-
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
         }
     });
-
     ObserverImageDIV();
 });
+
 var PopObserver = new MutationObserver(function (mutations) {
     PopObserver.disconnect();
     mutations.forEach(mutation => {
@@ -2142,13 +2135,13 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (!doBattleTrans) {
+    if (doBattleTrans) {
         if (doc.URL.includes('#raid')) {
             archiveObserver.disconnect();
+            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
     }
-
     archiveObserver.observe(oText, config);
 }
 
@@ -2289,37 +2282,38 @@ async function ObserverBattle() {
     }
 }
 async function ObserverImage() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImage, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImage, generalConfig.refreshRate);
+            return;
+        }
     }
-    ImageObserver.observe(allElements, config);
-    ImageObserver.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserver.observe(allElements, config_image);
 }
 async function ObserverImageDIV() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+            return;
+        }
     }
-
-    ImageObserverDIV.observe(allElements, config);
-    ImageObserverDIV.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserverDIV.observe(allElements, config_image);
 }
 
 const main = async () => {

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -36,7 +36,7 @@ var kCheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/; // regeexp for finding Korean (source:
 var kCheckSpecial = /[\{\}\[\]\/?.,;:～：|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi; // regex for removing special characters
 
 var config = {
-    attributes: true,
+    //attributes: true,
     childList: true,
     subtree: true,
     characterData: true
@@ -1308,41 +1308,41 @@ const parseCsv = str => {
 //     });
 // }
 async function InitList() {
-//     var chromeOptions = await readChromeOption([
-//         'battleFullInfo',
-//         'sceneFullInfo',
-//         'nTEXT',
-//         'mTEXT',
-//         'verboseMode',
-//         'origin',
-//         'imageswap',
-//         'battleobserver',
-//         'extractMode',
-//         'translateMode',
-//         'userFont',
-//         'userFontName',
-//         'nonTransText'
-//     ]);
-//     if (chromeOptions.sceneFullInfo)
-//         sceneFullInfo = chromeOptions.sceneFullInfo;
-//     if (chromeOptions.battleFullInfo)
-//         battleFullInfo = chromeOptions.battleFullInfo;
-//     if (chromeOptions.nTEXT)
-//         cNames = chromeOptions.nTEXT;
-//     if (chromeOptions.mTEXT)
-//         miscs = chromeOptions.mTEXT;
-//     doImageSwap = chromeOptions.imageswap;
-//     doBattleTrans = chromeOptions.battleobserver;
-//     isVerboseMode = chromeOptions.verboseMode;
-//     transMode = chromeOptions.translateMode;
-//     exMode = chromeOptions.extractMode;
-//     skipTranslatedText = chromeOptions.nonTransText;
-//     if (chromeOptions.origin) {
-//         generalConfig.origin = chromeOptions.origin;
-//     } else
-//         generalConfig.origin = 'chrome-extension://' + chrome.runtime.id;
-//     if (chromeOptions.userFont)
-//         generalConfig.defaultFont = chromeOptions.userFont;
+    // var chromeOptions = await readChromeOption([
+    //     'battleFullInfo',
+    //     'sceneFullInfo',
+    //     'nTEXT',
+    //     'mTEXT',
+    //     'verboseMode',
+    //     'origin',
+    //     'imageswap',
+    //     'battleobserver',
+    //     'extractMode',
+    //     'translateMode',
+    //     'userFont',
+    //     'userFontName',
+    //     'nonTransText'
+    // ]);
+    // if (chromeOptions.sceneFullInfo)
+    //     sceneFullInfo = chromeOptions.sceneFullInfo;
+    // if (chromeOptions.battleFullInfo)
+    //     battleFullInfo = chromeOptions.battleFullInfo;
+    // if (chromeOptions.nTEXT)
+    //     cNames = chromeOptions.nTEXT;
+    // if (chromeOptions.mTEXT)
+    //     miscs = chromeOptions.mTEXT;
+    // doImageSwap = chromeOptions.imageswap;
+    // doBattleTrans = chromeOptions.battleobserver;
+    // isVerboseMode = chromeOptions.verboseMode;
+    // transMode = chromeOptions.translateMode;
+    // exMode = chromeOptions.extractMode;
+    // skipTranslatedText = chromeOptions.nonTransText;
+    // if (chromeOptions.origin) {
+    //     generalConfig.origin = chromeOptions.origin;
+    // } else
+    //     generalConfig.origin = 'chrome-extension://' + chrome.runtime.id;
+    // if (chromeOptions.userFont)
+    //     generalConfig.defaultFont = chromeOptions.userFont;
 
     // Use custom font
     var styles = `@font-face {font-family: 'CustomFont';src: url('http://game-a.granbluefantasy.jp/assets/font/basic_alphabet.woff') format('woff');}
@@ -1371,7 +1371,7 @@ async function InitList() {
         ObserverList = [
             ObserveSceneText(),
             ObserverArchive(),
-            ObserverPop(),
+            //ObserverPop(),
             ObserverStorySelectTexts()
         ];
         if (doImageSwap) ObserverList.push(ObserverImageDIV(), ObserverImage());
@@ -1887,7 +1887,7 @@ function GetTranslatedImageDIV(node, csv) {
             imageStyle = imageStyleCompute;
         if (UseComputeAfter)
             imageStyle = imageStyleComputeAfter;
-        if (!imageStyle)  return;
+        if (!imageStyle) return;
         if (textInput.includes(generalConfig.origin)) return;
         if (!imageStyle.includes('png') ||
             imageStyle.includes('/ui/') ||
@@ -2031,9 +2031,7 @@ var archiveObserver = new MutationObserver(function (mutations) {
         if (mutation.target) {
             if (
                 !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name') &&
-                !mutation.target.className.includes('wrapper') &&
-                !mutation.target.className.includes('contents')
+                !mutation.target.className.includes('txt-character-name')
             ) {
                 walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
@@ -2046,7 +2044,7 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
+            if (mutation.target.className &&
                 mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
@@ -2061,10 +2059,10 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
-                mutation.target.className == 'contents' || 
+            if (mutation.target.className &&
+                mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
-                    
+
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
             }
 
@@ -2094,8 +2092,8 @@ var BattleObserver = new MutationObserver(function (mutations) {
     mutations.forEach(mutation => {
         walkDownTree(mutation.target, GetTranslatedText, archiveJson);
         GetTranslatedBattleText(mutation.target, battleJson);
-        
-        if(doImageSwap)
+
+        if (doImageSwap)
             walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
     });
     ObserverBattle();
@@ -2103,7 +2101,7 @@ var BattleObserver = new MutationObserver(function (mutations) {
 
 var BattleImageObserver = new MutationObserver(function (mutations) {
     BattleImageObserver.disconnect();
-    mutations.forEach(mutation => {	
+    mutations.forEach(mutation => {
         walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
 
         var btn_recovery = doc.querySelectorAll('[class^="btn-temporary"]');
@@ -2144,20 +2142,11 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-        return;
-    }
-    if (
-        doc.URL.includes('archive') ||
-        doc.URL.includes('scene') ||
-        doc.URL.includes('story') ||
-        doc.URL.includes('tutorial')
-    ) {
-        ObserverPop();
-        archiveObserver.observe(oText, config);
-        ObserveSceneText();
-        ObserverStorySelectTexts();
+    if (!doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            archiveObserver.disconnect();
+            return;
+        }
     }
 
     archiveObserver.observe(oText, config);
@@ -2259,26 +2248,26 @@ async function ObserverBattle() {
         }
         var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
         if (battleInfo_btn) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
         }
-        
+
         var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
         if (battleInfo_subbtn) {
             walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
         }
         var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
         if (battleInfo_contrib) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
         }
-        
+
         var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
         if (multilog_overlayer) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(multilog_overlayer, BattleImageObserver, config);
         }
-        
+
         var popDIV = doc.getElementById('pop');
         if (popDIV) {
             PopObserver.observe(popDIV, config);

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2141,13 +2141,6 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            archiveObserver.disconnect();
-            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2047,18 +2047,24 @@ var archiveObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserver.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
+            }
         }
     });
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
+    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap && mutation.target.className) {
-            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            if (doImageSwap && mutation.target.className) {
+                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+            }
         }
     });
     ObserverImageDIV();

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2293,16 +2293,10 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImage, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
     ImageObserver.observe(allElements, config_image);

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2044,11 +2044,11 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            }
+            // }
         }
     });
     ObserverImage();
@@ -2059,12 +2059,12 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className &&
-                mutation.target.className == 'contents' ||
-                mutation.target.className.includes('pop-global-menu')) {
+            // if (mutation.target.className &&
+            //     mutation.target.className == 'contents' ||
+            //     mutation.target.className.includes('pop-global-menu')) {
 
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            }
+            // }
 
         }
     });

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2309,16 +2309,10 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans ) {
-        if(doc.URL.includes('#raid')){
-            ImageObserver.disconnect();
-            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-            return;
-        }
-    }
     if(doc.URL.includes('#raid')){
+        ImageObserver.disconnect();
         archiveObserver.disconnect();
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
         return;
     }
     ImageObserverDIV.observe(allElements, config_image);

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -41,6 +41,12 @@ var config = {
     subtree: true,
     characterData: true
 };
+var config_image = {
+    attributes: true,
+    //childList: true,
+    subtree: true,
+    //characterData: true
+};
 var config_simple = {
     attributes: true,
 };
@@ -1859,7 +1865,7 @@ function GetTranslatedImage(node, csv) {
         )
             return;
         PrintLog(`Send Image URL:${imageInput}`);
-        if (transMode)
+        if (transMode && doImageSwap)
             translatedText = GetTranslatedImageURL(imageInput, csv);
         if (translatedText.length > 0) {
             // When it founds the translated text
@@ -2041,36 +2047,23 @@ var archiveObserver = new MutationObserver(function (mutations) {
 });
 var ImageObserver = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-    ImageObserver.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
-            // }
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
         }
     });
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
     // PrintLog(mutations);
-
-    ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
-        if (doImageSwap) {
-            // if (mutation.target.className &&
-            //     mutation.target.className == 'contents' ||
-            //     mutation.target.className.includes('pop-global-menu')) {
-
-                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-            // }
-
+        if (doImageSwap && mutation.target.className) {
+            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
         }
     });
-
     ObserverImageDIV();
 });
+
 var PopObserver = new MutationObserver(function (mutations) {
     PopObserver.disconnect();
     mutations.forEach(mutation => {
@@ -2142,13 +2135,13 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (!doBattleTrans) {
+    if (doBattleTrans) {
         if (doc.URL.includes('#raid')) {
             archiveObserver.disconnect();
+            window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
     }
-
     archiveObserver.observe(oText, config);
 }
 
@@ -2289,37 +2282,38 @@ async function ObserverBattle() {
     }
 }
 async function ObserverImage() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImage, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImage, generalConfig.refreshRate);
+            return;
+        }
     }
-    ImageObserver.observe(allElements, config);
-    ImageObserver.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserver.observe(allElements, config_image);
 }
 async function ObserverImageDIV() {
-    var allElements = doc.querySelectorAll('[class^="contents"]')[0];
-    // var allElements = doc.getElementById('wrapper');
+    var allElements = doc.getElementById('wrapper');
     if (!allElements) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+        window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
-        return;
+    if (doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            ImageObserver.disconnect();
+            window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
+            return;
+        }
     }
-
-    ImageObserverDIV.observe(allElements, config);
-    ImageObserverDIV.observe(doc.querySelectorAll('[class^="pop-global-menu"]')[0], config); // Upper menu
+    ImageObserverDIV.observe(allElements, config_image);
 }
 
 const main = async () => {

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2142,11 +2142,16 @@ async function ObserverArchive() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             archiveObserver.disconnect();
             window.setTimeout(ObserverArchive, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     archiveObserver.observe(oText, config);
 }
@@ -2296,11 +2301,16 @@ async function ObserverImage() {
         return;
     }
     if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImage, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserver.observe(allElements, config_image);
 }
@@ -2312,12 +2322,17 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if (doBattleTrans) {
-        if (doc.URL.includes('#raid')) {
+    if (doBattleTrans ) {
+        if(doc.URL.includes('#raid')){
             ImageObserver.disconnect();
             window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
             return;
         }
+    }
+    if(doc.URL.includes('#raid')){
+        archiveObserver.disconnect();
+        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
+        return;
     }
     ImageObserverDIV.observe(allElements, config_image);
 }

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -36,7 +36,7 @@ var kCheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/; // regeexp for finding Korean (source:
 var kCheckSpecial = /[\{\}\[\]\/?.,;:～：|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi; // regex for removing special characters
 
 var config = {
-    attributes: true,
+    //attributes: true,
     childList: true,
     subtree: true,
     characterData: true
@@ -1308,41 +1308,41 @@ const parseCsv = str => {
 //     });
 // }
 async function InitList() {
-//     var chromeOptions = await readChromeOption([
-//         'battleFullInfo',
-//         'sceneFullInfo',
-//         'nTEXT',
-//         'mTEXT',
-//         'verboseMode',
-//         'origin',
-//         'imageswap',
-//         'battleobserver',
-//         'extractMode',
-//         'translateMode',
-//         'userFont',
-//         'userFontName',
-//         'nonTransText'
-//     ]);
-//     if (chromeOptions.sceneFullInfo)
-//         sceneFullInfo = chromeOptions.sceneFullInfo;
-//     if (chromeOptions.battleFullInfo)
-//         battleFullInfo = chromeOptions.battleFullInfo;
-//     if (chromeOptions.nTEXT)
-//         cNames = chromeOptions.nTEXT;
-//     if (chromeOptions.mTEXT)
-//         miscs = chromeOptions.mTEXT;
-//     doImageSwap = chromeOptions.imageswap;
-//     doBattleTrans = chromeOptions.battleobserver;
-//     isVerboseMode = chromeOptions.verboseMode;
-//     transMode = chromeOptions.translateMode;
-//     exMode = chromeOptions.extractMode;
-//     skipTranslatedText = chromeOptions.nonTransText;
-//     if (chromeOptions.origin) {
-//         generalConfig.origin = chromeOptions.origin;
-//     } else
-//         generalConfig.origin = 'chrome-extension://' + chrome.runtime.id;
-//     if (chromeOptions.userFont)
-//         generalConfig.defaultFont = chromeOptions.userFont;
+    // var chromeOptions = await readChromeOption([
+    //     'battleFullInfo',
+    //     'sceneFullInfo',
+    //     'nTEXT',
+    //     'mTEXT',
+    //     'verboseMode',
+    //     'origin',
+    //     'imageswap',
+    //     'battleobserver',
+    //     'extractMode',
+    //     'translateMode',
+    //     'userFont',
+    //     'userFontName',
+    //     'nonTransText'
+    // ]);
+    // if (chromeOptions.sceneFullInfo)
+    //     sceneFullInfo = chromeOptions.sceneFullInfo;
+    // if (chromeOptions.battleFullInfo)
+    //     battleFullInfo = chromeOptions.battleFullInfo;
+    // if (chromeOptions.nTEXT)
+    //     cNames = chromeOptions.nTEXT;
+    // if (chromeOptions.mTEXT)
+    //     miscs = chromeOptions.mTEXT;
+    // doImageSwap = chromeOptions.imageswap;
+    // doBattleTrans = chromeOptions.battleobserver;
+    // isVerboseMode = chromeOptions.verboseMode;
+    // transMode = chromeOptions.translateMode;
+    // exMode = chromeOptions.extractMode;
+    // skipTranslatedText = chromeOptions.nonTransText;
+    // if (chromeOptions.origin) {
+    //     generalConfig.origin = chromeOptions.origin;
+    // } else
+    //     generalConfig.origin = 'chrome-extension://' + chrome.runtime.id;
+    // if (chromeOptions.userFont)
+    //     generalConfig.defaultFont = chromeOptions.userFont;
 
     // Use custom font
     var styles = `@font-face {font-family: 'CustomFont';src: url('http://game-a.granbluefantasy.jp/assets/font/basic_alphabet.woff') format('woff');}
@@ -1371,7 +1371,7 @@ async function InitList() {
         ObserverList = [
             ObserveSceneText(),
             ObserverArchive(),
-            ObserverPop(),
+            //ObserverPop(),
             ObserverStorySelectTexts()
         ];
         if (doImageSwap) ObserverList.push(ObserverImageDIV(), ObserverImage());
@@ -1887,7 +1887,7 @@ function GetTranslatedImageDIV(node, csv) {
             imageStyle = imageStyleCompute;
         if (UseComputeAfter)
             imageStyle = imageStyleComputeAfter;
-        if (!imageStyle)  return;
+        if (!imageStyle) return;
         if (textInput.includes(generalConfig.origin)) return;
         if (!imageStyle.includes('png') ||
             imageStyle.includes('/ui/') ||
@@ -2031,9 +2031,7 @@ var archiveObserver = new MutationObserver(function (mutations) {
         if (mutation.target) {
             if (
                 !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name') &&
-                !mutation.target.className.includes('wrapper') &&
-                !mutation.target.className.includes('contents')
+                !mutation.target.className.includes('txt-character-name')
             ) {
                 walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
@@ -2046,7 +2044,7 @@ var ImageObserver = new MutationObserver(function (mutations) {
     ImageObserver.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
+            if (mutation.target.className &&
                 mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
                 walkDownTreeSrc(mutation.target, GetTranslatedImage, imageJson);
@@ -2061,10 +2059,10 @@ var ImageObserverDIV = new MutationObserver(function (mutations) {
     ImageObserverDIV.disconnect();
     mutations.forEach(mutation => {
         if (doImageSwap) {
-            if (mutation.target.className && 
-                mutation.target.className == 'contents' || 
+            if (mutation.target.className &&
+                mutation.target.className == 'contents' ||
                 mutation.target.className.includes('pop-global-menu')) {
-                    
+
                 walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
             }
 
@@ -2094,8 +2092,8 @@ var BattleObserver = new MutationObserver(function (mutations) {
     mutations.forEach(mutation => {
         walkDownTree(mutation.target, GetTranslatedText, archiveJson);
         GetTranslatedBattleText(mutation.target, battleJson);
-        
-        if(doImageSwap)
+
+        if (doImageSwap)
             walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
     });
     ObserverBattle();
@@ -2103,7 +2101,7 @@ var BattleObserver = new MutationObserver(function (mutations) {
 
 var BattleImageObserver = new MutationObserver(function (mutations) {
     BattleImageObserver.disconnect();
-    mutations.forEach(mutation => {	
+    mutations.forEach(mutation => {
         walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
 
         var btn_recovery = doc.querySelectorAll('[class^="btn-temporary"]');
@@ -2144,20 +2142,11 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('#raid')) {
-        window.setTimeout(ObserverArchive, generalConfig.refreshRate);
-        return;
-    }
-    if (
-        doc.URL.includes('archive') ||
-        doc.URL.includes('scene') ||
-        doc.URL.includes('story') ||
-        doc.URL.includes('tutorial')
-    ) {
-        ObserverPop();
-        archiveObserver.observe(oText, config);
-        ObserveSceneText();
-        ObserverStorySelectTexts();
+    if (!doBattleTrans) {
+        if (doc.URL.includes('#raid')) {
+            archiveObserver.disconnect();
+            return;
+        }
     }
 
     archiveObserver.observe(oText, config);
@@ -2259,26 +2248,26 @@ async function ObserverBattle() {
         }
         var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
         if (battleInfo_btn) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
         }
-        
+
         var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
         if (battleInfo_subbtn) {
             walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
         }
         var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
         if (battleInfo_contrib) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
         }
-        
+
         var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
         if (multilog_overlayer) {
-            if(doImageSwap)
+            if (doImageSwap)
                 walkDownObserver(multilog_overlayer, BattleImageObserver, config);
         }
-        
+
         var popDIV = doc.getElementById('pop');
         if (popDIV) {
             PopObserver.observe(popDIV, config);


### PR DESCRIPTION
archiveObserver에 관해서는 거의 최대의 퍼포먼스까지 끌어올린것같음.
```
var config = {
    //attributes: true,
    childList: true,
    subtree: true,
    characterData: true
};
```
첫째줄``` //attributes: true,``` 이것만 주석처리하고 보니까 과도한 mutation이 일어나지않아서 깔끔하게 작동함.

트리 순회를 덜하게할려고 이것저것 알아보느라 이틀이 순삭됐는데 아무튼 여러가지 방법중에 저거 주석처리하는게 가장 깔끔한 결과를 냈음.

### 퍼포먼스 결과, 번역툴 미적용과 동일한 퍼포먼스 나옴.
![1](https://camo.githubusercontent.com/1bc2a32480d9b9c864a9649556dd16679332b33b4316bd2f6c7138d906f84c1b/68747470733a2f2f696d6775722e636f6d2f4c514f375869462e706e67)

<br>
<br>

### 테스트 환경
 메인화면 -> 퀘스트 -> 서포터 선택 화면 -> 전투 화면 -> 클리어 -> 메인화면

이렇게 새로고침 없이 수행했는데 미번역 되는 부분은 없었음. 

이번엔 진짜 완벽. 아마도.