### PR TITLE
전투 화면 이미지 번역 지연 이슈 해결

### DIFF
--- a/content.js
+++ b/content.js
@@ -2186,7 +2186,8 @@ function GetTranslatedStoryText(node, csv) {
 function GetTranslatedBattleText(node, csv) {
     if (node) {
         if (node.className.includes('txt-body') ||
-            node.className.includes('txt-title')) {
+            node.className.includes('txt-title') || 
+            node.className.includes('prt-advice')) {
             if (node.innerHTML && node.innerHTML.length == 0) return;
             var translatedText = '';
 

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -1823,7 +1823,8 @@ function GetTranslatedStoryText(node, csv) {
 function GetTranslatedBattleText(node, csv) {
     if (node) {
         if (node.className.includes('txt-body') ||
-            node.className.includes('txt-title')) {
+            node.className.includes('txt-title') || 
+            node.className.includes('prt-advice')) {
             if (node.innerHTML && node.innerHTML.length == 0) return;
             var translatedText = '';
 

--- a/gbfTrans.js
+++ b/gbfTrans.js
@@ -1889,6 +1889,16 @@ function GetTranslatedImageDIV(node, csv) {
             true :
             false;
         var translatedImage = '';
+        if (node.className == 'btn-assist' /* includes로 검사하면 비슷한 이름의 노드가 2개 걸림. */ ||
+            node.className.includes('btn-alliance') ||
+            node.className.includes('btn-logs')) {
+            if (imageStyle.includes('none') /* 화면이 완전히 표시되기전까지는 none값으로 있음. */ ) {
+                window.setTimeout(() => {
+                    GetTranslatedImageDIV(node, csv);
+                    return;
+                }, generalConfig.refreshRate);
+            }
+        }
         if (UseCompute)
             imageStyle = imageStyleCompute;
         if (UseComputeAfter)
@@ -1927,7 +1937,7 @@ function GetTranslatedImageDIV(node, csv) {
 
         if (transMode && doImageSwap)
             translatedImage = GetTranslatedImageStyle(imageStyle, csv);
-
+            
         if (translatedImage && translatedImage.length > 0) {
             // When it founds the translated text
             if (UseComputeAfter) {
@@ -2034,14 +2044,20 @@ var sceneObserver = new MutationObserver(function (mutations) {
 var archiveObserver = new MutationObserver(function (mutations) {
     archiveObserver.disconnect();
     mutations.forEach(mutation => {
-            if (mutation.target) {
-                if (
-                    !mutation.target.className.includes('txt-message') &&
-                    !mutation.target.className.includes('txt-character-name')
-                ) {
-                    walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+        if (mutation.target) {
+            if (
+                !mutation.target.className.includes('txt-message') &&
+                !mutation.target.className.includes('txt-character-name')
+            ) {
+                if (mutation.target.className == 'contents') {
+                    //mutation 감지되는 노드중에 contents의 부모 노드인 wrapper 노드가 감지가 안됨.
+                    //그래서 contents 노드가 감지될때 부모 노드 wrapper를 번역하게함. 퍼포먼스 영향 없었음.
+                    walkDownTree(doc.getElementById('wrapper'), GetTranslatedText, archiveJson);
+                    return;
                 }
+                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
+        }
     });
     ObserverArchive();
 });
@@ -2089,11 +2105,10 @@ var PopObserver = new MutationObserver(function (mutations) {
 var BattleObserver = new MutationObserver(function (mutations) {
     BattleObserver.disconnect();
     mutations.forEach(mutation => {
-        walkDownTree(mutation.target, GetTranslatedText, archiveJson);
-        GetTranslatedBattleText(mutation.target, battleJson);
-
-        if (doImageSwap)
-            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+            GetTranslatedBattleText(mutation.target, battleJson /* battleJson은 questJson과 다르게 sceneCode값이 없는 말풍선 번역문들이기 때문에 archiveJson과 합쳐도 무방해보임. 좀 더 생각해보기.*/ );
+        }
     });
     ObserverBattle();
 });
@@ -2101,12 +2116,9 @@ var BattleObserver = new MutationObserver(function (mutations) {
 var BattleImageObserver = new MutationObserver(function (mutations) {
     BattleImageObserver.disconnect();
     mutations.forEach(mutation => {
-        walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-
-        var btn_recovery = doc.querySelectorAll('[class^="btn-temporary"]');
-        walkDownTreeStyle(btn_recovery, GetTranslatedImageDIV, imageJson);
-        var multi_buttons = doc.querySelectorAll('[class^="prt-multi-buttons"]');
-        walkDownTreeStyle(multi_buttons, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        }
     });
     ObserverBattle();
 });
@@ -2133,7 +2145,6 @@ async function ObserveSceneText() {
 }
 
 async function ObserverArchive() {
-    // var oText = doc.getElementById('loading');
     var oText = doc.getElementById('wrapper');
     if (!oText) {
         //The node we need does not exist yet.
@@ -2141,7 +2152,7 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
@@ -2209,7 +2220,8 @@ async function ObserverPop() {
 }
 async function ObserverBattle() {
     // var oText = doc.querySelector(".prt-scroll-title");
-    var oText = doc.querySelectorAll('[class^="prt-command-chara"]')[0];
+    // var oText = doc.querySelectorAll('[class^="prt-command-chara"]')[0];
+    var oText = doc.getElementById('wrapper');
     if (!oText) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
@@ -2217,72 +2229,81 @@ async function ObserverBattle() {
         return;
     }
     if (doc.URL.includes('#raid') || doc.URL.includes('/#tutorial/') /* for tutorial page */ ) {
+        if (doBattleTrans) {
+            BattleObserver.observe(oText, config);
+            BattleImageObserver.observe(oText, config);
+        } else {
+            BattleObserver.disconnect();
+            BattleImageObserver.disconnect();
+            window.setTimeout(ObserverBattle, generalConfig.refreshRate);
+            return;
+        }
         // In battle window, try to use 'white list' to get 
 
-        var battleInfo1 = doc.querySelectorAll('[class^="prt-command-chara"]');
-        if (battleInfo1) {
-            battleInfo1.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo2 = doc.querySelectorAll('[class^="pop-condition"]');
-        if (battleInfo2) {
-            battleInfo2.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo3 = doc.querySelectorAll('[class^="txt-cutin"]');
-        if (battleInfo3) {
-            battleInfo3.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo4 = doc.querySelectorAll('[class^="pop-usual"]');
-        if (battleInfo4) {
-            battleInfo4.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
-        if (battleInfo_btn) {
-            if (doImageSwap)
-                walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
-        }
+        // var battleInfo1 = doc.querySelectorAll('[class^="prt-command-chara"]');
+        // if (battleInfo1) {
+        //     battleInfo1.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo2 = doc.querySelectorAll('[class^="pop-condition"]');
+        // if (battleInfo2) {
+        //     battleInfo2.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo3 = doc.querySelectorAll('[class^="txt-cutin"]');
+        // if (battleInfo3) {
+        //     battleInfo3.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo4 = doc.querySelectorAll('[class^="pop-usual"]');
+        // if (battleInfo4) {
+        //     battleInfo4.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
+        // if (battleInfo_btn) {
+        //     if (doImageSwap)
+        //         walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
+        // }
 
-        var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
-        if (battleInfo_subbtn) {
-            walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
-        }
-        var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
-        if (battleInfo_contrib) {
-            if (doImageSwap)
-                walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
-        }
+        // var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
+        // if (battleInfo_subbtn) {
+        //     walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
+        // }
+        // var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
+        // if (battleInfo_contrib) {
+        //     if (doImageSwap)
+        //         walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
+        // }
 
-        var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
-        if (multilog_overlayer) {
-            if (doImageSwap)
-                walkDownObserver(multilog_overlayer, BattleImageObserver, config);
-        }
+        // var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
+        // if (multilog_overlayer) {
+        //     if (doImageSwap)
+        //         walkDownObserver(multilog_overlayer, BattleImageObserver, config);
+        // }
 
-        var popDIV = doc.getElementById('pop');
-        if (popDIV) {
-            PopObserver.observe(popDIV, config);
-        }
+        // var popDIV = doc.getElementById('pop');
+        // if (popDIV) {
+        //     PopObserver.observe(popDIV, config);
+        // }
 
-        var battleConditionInfo = doc.querySelectorAll('[class^="prt-battle-condition"]');
-        if (battleConditionInfo) {
-            battleConditionInfo.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config);
-            });
-        }
+        // var battleConditionInfo = doc.querySelectorAll('[class^="prt-battle-condition"]');
+        // if (battleConditionInfo) {
+        //     battleConditionInfo.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config);
+        //     });
+        // }
 
-        var battleNavi = doc.querySelectorAll('[class^="prt-navi btn-scene-next"]');
-        if (battleNavi) {
-            battleNavi.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
+        // var battleNavi = doc.querySelectorAll('[class^="prt-navi btn-scene-next"]');
+        // if (battleNavi) {
+        //     battleNavi.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
     }
 }
 async function ObserverImage() {
@@ -2293,7 +2314,7 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
@@ -2309,7 +2330,7 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -1823,7 +1823,8 @@ function GetTranslatedStoryText(node, csv) {
 function GetTranslatedBattleText(node, csv) {
     if (node) {
         if (node.className.includes('txt-body') ||
-            node.className.includes('txt-title')) {
+            node.className.includes('txt-title') || 
+            node.className.includes('prt-advice')) {
             if (node.innerHTML && node.innerHTML.length == 0) return;
             var translatedText = '';
 

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -1889,6 +1889,16 @@ function GetTranslatedImageDIV(node, csv) {
             true :
             false;
         var translatedImage = '';
+        if (node.className == 'btn-assist' /* includes로 검사하면 비슷한 이름의 노드가 2개 걸림. */ ||
+            node.className.includes('btn-alliance') ||
+            node.className.includes('btn-logs')) {
+            if (imageStyle.includes('none') /* 화면이 완전히 표시되기전까지는 none값으로 있음. */ ) {
+                window.setTimeout(() => {
+                    GetTranslatedImageDIV(node, csv);
+                    return;
+                }, generalConfig.refreshRate);
+            }
+        }
         if (UseCompute)
             imageStyle = imageStyleCompute;
         if (UseComputeAfter)
@@ -1927,7 +1937,7 @@ function GetTranslatedImageDIV(node, csv) {
 
         if (transMode && doImageSwap)
             translatedImage = GetTranslatedImageStyle(imageStyle, csv);
-
+            
         if (translatedImage && translatedImage.length > 0) {
             // When it founds the translated text
             if (UseComputeAfter) {
@@ -2039,6 +2049,12 @@ var archiveObserver = new MutationObserver(function (mutations) {
                 !mutation.target.className.includes('txt-message') &&
                 !mutation.target.className.includes('txt-character-name')
             ) {
+                if (mutation.target.className == 'contents') {
+                    //mutation 감지되는 노드중에 contents의 부모 노드인 wrapper 노드가 감지가 안됨.
+                    //그래서 contents 노드가 감지될때 부모 노드 wrapper를 번역하게함. 퍼포먼스 영향 없었음.
+                    walkDownTree(doc.getElementById('wrapper'), GetTranslatedText, archiveJson);
+                    return;
+                }
                 walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
         }
@@ -2089,11 +2105,10 @@ var PopObserver = new MutationObserver(function (mutations) {
 var BattleObserver = new MutationObserver(function (mutations) {
     BattleObserver.disconnect();
     mutations.forEach(mutation => {
-        walkDownTree(mutation.target, GetTranslatedText, archiveJson);
-        GetTranslatedBattleText(mutation.target, battleJson);
-
-        if (doImageSwap)
-            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            walkDownTree(mutation.target, GetTranslatedText, archiveJson);
+            GetTranslatedBattleText(mutation.target, battleJson /* battleJson은 questJson과 다르게 sceneCode값이 없는 말풍선 번역문들이기 때문에 archiveJson과 합쳐도 무방해보임. 좀 더 생각해보기.*/ );
+        }
     });
     ObserverBattle();
 });
@@ -2101,12 +2116,9 @@ var BattleObserver = new MutationObserver(function (mutations) {
 var BattleImageObserver = new MutationObserver(function (mutations) {
     BattleImageObserver.disconnect();
     mutations.forEach(mutation => {
-        walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
-
-        var btn_recovery = doc.querySelectorAll('[class^="btn-temporary"]');
-        walkDownTreeStyle(btn_recovery, GetTranslatedImageDIV, imageJson);
-        var multi_buttons = doc.querySelectorAll('[class^="prt-multi-buttons"]');
-        walkDownTreeStyle(multi_buttons, GetTranslatedImageDIV, imageJson);
+        if (mutation.target) {
+            walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageJson);
+        }
     });
     ObserverBattle();
 });
@@ -2133,7 +2145,6 @@ async function ObserveSceneText() {
 }
 
 async function ObserverArchive() {
-    // var oText = doc.getElementById('loading');
     var oText = doc.getElementById('wrapper');
     if (!oText) {
         //The node we need does not exist yet.
@@ -2141,7 +2152,7 @@ async function ObserverArchive() {
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         archiveObserver.disconnect();
         window.setTimeout(ObserverArchive, generalConfig.refreshRate);
         return;
@@ -2209,7 +2220,8 @@ async function ObserverPop() {
 }
 async function ObserverBattle() {
     // var oText = doc.querySelector(".prt-scroll-title");
-    var oText = doc.querySelectorAll('[class^="prt-command-chara"]')[0];
+    // var oText = doc.querySelectorAll('[class^="prt-command-chara"]')[0];
+    var oText = doc.getElementById('wrapper');
     if (!oText) {
         //The node we need does not exist yet.
         //Wait 500ms and try again
@@ -2217,72 +2229,81 @@ async function ObserverBattle() {
         return;
     }
     if (doc.URL.includes('#raid') || doc.URL.includes('/#tutorial/') /* for tutorial page */ ) {
+        if (doBattleTrans) {
+            BattleObserver.observe(oText, config);
+            BattleImageObserver.observe(oText, config);
+        } else {
+            BattleObserver.disconnect();
+            BattleImageObserver.disconnect();
+            window.setTimeout(ObserverBattle, generalConfig.refreshRate);
+            return;
+        }
         // In battle window, try to use 'white list' to get 
 
-        var battleInfo1 = doc.querySelectorAll('[class^="prt-command-chara"]');
-        if (battleInfo1) {
-            battleInfo1.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo2 = doc.querySelectorAll('[class^="pop-condition"]');
-        if (battleInfo2) {
-            battleInfo2.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo3 = doc.querySelectorAll('[class^="txt-cutin"]');
-        if (battleInfo3) {
-            battleInfo3.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo4 = doc.querySelectorAll('[class^="pop-usual"]');
-        if (battleInfo4) {
-            battleInfo4.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
-        var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
-        if (battleInfo_btn) {
-            if (doImageSwap)
-                walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
-        }
+        // var battleInfo1 = doc.querySelectorAll('[class^="prt-command-chara"]');
+        // if (battleInfo1) {
+        //     battleInfo1.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo2 = doc.querySelectorAll('[class^="pop-condition"]');
+        // if (battleInfo2) {
+        //     battleInfo2.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo3 = doc.querySelectorAll('[class^="txt-cutin"]');
+        // if (battleInfo3) {
+        //     battleInfo3.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo4 = doc.querySelectorAll('[class^="pop-usual"]');
+        // if (battleInfo4) {
+        //     battleInfo4.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
+        // var battleInfo_btn = doc.querySelectorAll('[class^="prt-sub-command"]');
+        // if (battleInfo_btn) {
+        //     if (doImageSwap)
+        //         walkDownObserver(battleInfo_btn, BattleImageObserver, config_simple);
+        // }
 
-        var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
-        if (battleInfo_subbtn) {
-            walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
-        }
-        var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
-        if (battleInfo_contrib) {
-            if (doImageSwap)
-                walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
-        }
+        // var battleInfo_subbtn = doc.querySelectorAll('[class^="prt-multi-buttons"]');
+        // if (battleInfo_subbtn) {
+        //     walkDownObserver(battleInfo_subbtn, BattleImageObserver, config_simple);
+        // }
+        // var battleInfo_contrib = doc.querySelectorAll('[class^="prt-contribution"]');
+        // if (battleInfo_contrib) {
+        //     if (doImageSwap)
+        //         walkDownObserver(battleInfo_contrib, BattleImageObserver, config_simple);
+        // }
 
-        var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
-        if (multilog_overlayer) {
-            if (doImageSwap)
-                walkDownObserver(multilog_overlayer, BattleImageObserver, config);
-        }
+        // var multilog_overlayer = doc.querySelectorAll('[class^="prt-multilog-overlayer"]');
+        // if (multilog_overlayer) {
+        //     if (doImageSwap)
+        //         walkDownObserver(multilog_overlayer, BattleImageObserver, config);
+        // }
 
-        var popDIV = doc.getElementById('pop');
-        if (popDIV) {
-            PopObserver.observe(popDIV, config);
-        }
+        // var popDIV = doc.getElementById('pop');
+        // if (popDIV) {
+        //     PopObserver.observe(popDIV, config);
+        // }
 
-        var battleConditionInfo = doc.querySelectorAll('[class^="prt-battle-condition"]');
-        if (battleConditionInfo) {
-            battleConditionInfo.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config);
-            });
-        }
+        // var battleConditionInfo = doc.querySelectorAll('[class^="prt-battle-condition"]');
+        // if (battleConditionInfo) {
+        //     battleConditionInfo.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config);
+        //     });
+        // }
 
-        var battleNavi = doc.querySelectorAll('[class^="prt-navi btn-scene-next"]');
-        if (battleNavi) {
-            battleNavi.forEach(bInfo => {
-                BattleObserver.observe(bInfo, config_simple);
-            });
-        }
+        // var battleNavi = doc.querySelectorAll('[class^="prt-navi btn-scene-next"]');
+        // if (battleNavi) {
+        //     battleNavi.forEach(bInfo => {
+        //         BattleObserver.observe(bInfo, config_simple);
+        //     });
+        // }
     }
 }
 async function ObserverImage() {
@@ -2293,7 +2314,7 @@ async function ObserverImage() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
@@ -2309,7 +2330,7 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImage, generalConfig.refreshRate);
         return;
     }
-    if(doc.URL.includes('#raid')){
+    if (doc.URL.includes('#raid')) {
         ImageObserver.disconnect();
         archiveObserver.disconnect();
         window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);


### PR DESCRIPTION
## 이미지 번역 지연 현상 
![1](https://user-images.githubusercontent.com/22585023/98957435-8ab42e00-2544-11eb-896e-0ad600364024.PNG)

전투 화면 맨 밑의 이 버튼들이 예전부터 번역이 안되거나 지연됐던 현상이 있었음.

알고보니 전투 화면이 완전히 렌더링 되기 전까지는 imageStyle 값이 none이였음. 

밑의 사진은 맨 밑의 버튼 3개에 대해서 imageStyle 값이 none일때 로그를 찍어본것임.
```
console.log(imageStyle); 
console.log(node); 
```

![2](https://user-images.githubusercontent.com/22585023/98957439-8be55b00-2544-11eb-8fdb-d9b56dfa0c57.PNG)

확실히 none값이 출력됨. 그래서 새로운 값이 할당될때까지 ```window.setTimeout``` 을 돌려봤더니 해결됨.

![3](https://user-images.githubusercontent.com/22585023/98957441-8be55b00-2544-11eb-83ff-04031e237108.PNG)


## ObserverBattle() 함수 코드 개선
최근 커밋의 Observer 함수들을 손보면서 이 함수도 건드려봤음.

전투화면에서 퍼포먼스가 하락되지 않으면서 번역되게끔 ObserverArchive 함수와 비슷한 형태로 코드를 개선해봄.

결과는 괜찮아보임. 이미지 번역 & 전투 화면에서 번역 옵션을 껐다켜보고 해봤는데 부하가 일어나거나 오작동이 보이진 않았음.

## 끝
이렇게 2개 부분을 건드려봤는데 어떤지 한번 봐줬음 좋겠음. 

아 그리고 최근 커밋한 버전은 핸드폰으로 테스트해보니까 확실히 빨라짐. 거의 네이티브급.

이제 pouchDB 라는 오프라인 DB를 도입해서 데이터 걱정없이 VPN을 사용할수있는 환경까지 갖추면 좋겠음.

이거를 다음 개발 목표로 할려고하는데 어떻게 생각함? 개선해야하는 더 불편한 부분이 있다거나.