### PR TITLE
전체적인 성능 개선. 유저 이름 추출시 [플레이어]로 변경.

### DIFF
--- a/content.js
+++ b/content.js
@@ -2804,7 +2804,7 @@ function GetTranslatedText(node, csv) {
             isNaN(textInput.replace('/', '')) == false || // number / number
             node.className && node.className.includes('txt-atk') ||
             node.className && node.className.includes('scene-font-place') ||
-            node.className && node.className.includes('prt-pop-synopsis') ||
+            (node.className && node.className.includes('prt-pop-synopsis') && !doc.URL.includes('#sidestory')) ||
             node.className && node.className.includes('txt-supporter-name') ||
             node.className && node.className.includes('txt-name') ||
             node.className && node.className.includes('txt-message')

--- a/content.js
+++ b/content.js
@@ -1922,7 +1922,7 @@ var updateDBTexts = async function () {
     dbNextUpdateTime_text = new Date();
     dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
     dbNextUpdateTime_image = new Date();
-    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+    dbNextUpdateTime_image.setHours(24 + 5, 0, 0, 0);
 
     return new Promise(function (resolve, reject) {
         var trx = dbDef.dbCon.transaction(dbDef.dbStoreName, "readwrite").objectStore(dbDef.dbStoreName);
@@ -1953,7 +1953,7 @@ var updateDBImages = async function () {
     dbNextUpdateTime_text = new Date();
     dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
     dbNextUpdateTime_image = new Date();
-    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+    dbNextUpdateTime_image.setHours(24 + 5, 0, 0, 0);
     imageJson = parseCsv(await request(generalConfig.origin + '/data/image.csv'));
     imageBlobs = [];
     imageBlobsUrl = [];
@@ -2523,7 +2523,7 @@ function RemoveTranslatedText() {
                 pass = false;
         });
         if (pass)
-        tempNamesArray.push(itemTemp);
+            tempNamesArray.push(itemTemp);
     });
     cNames = tempNamesArray;
 
@@ -2536,7 +2536,7 @@ function RemoveTranslatedText() {
                 pass = false;
         });
         if (pass)
-        tempMiscsArray.push(itemTemp);
+            tempMiscsArray.push(itemTemp);
     });
     miscs = tempMiscsArray;
 

--- a/content.js
+++ b/content.js
@@ -1936,7 +1936,8 @@ var updateDBTexts = async function () {
                 imageJson,
                 battleJson,
                 imageBlobs,
-                dbNextUpdateTime
+                dbNextUpdateTime_text,
+                dbNextUpdateTime_image
             });
             requestUpdate.onsuccess = function (event) {
                 PrintLog('업데이트 완료');

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -2230,7 +2230,7 @@ function GetTranslatedText(node, csv) {
             isNaN(textInput.replace('/', '')) == false || // number / number
             node.className && node.className.includes('txt-atk') ||
             node.className && node.className.includes('scene-font-place') ||
-            node.className && node.className.includes('prt-pop-synopsis') ||
+            (node.className && node.className.includes('prt-pop-synopsis') && !doc.URL.includes('#sidestory')) ||
             node.className && node.className.includes('txt-supporter-name') ||
             node.className && node.className.includes('txt-name') ||
             node.className && node.className.includes('txt-message')

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -4,12 +4,13 @@ var generalConfig = {
     origin: 'https://sidewinderk.github.io/gbfTransKor',
     // online DB: 'https://sidewinderk.github.io/gbfTransKor'
     // local DB: 'chrome-extension://'  + chrome.runtime.id
-    defaultNameMale_jp: "[グラン]", // Default original user name
-    defaultNameFemale_jp: "[ジータ]",
-    defaultNameMale_en: "[Gran]",
-    defaultNameFemale_en: "[Djeeta]",
-    defaultTransNameMale: "[그랑]", // Default translated user name
-    defaultTransNameFemale: "[지타]",
+    // defaultNameMale_jp: "[グラン]", // Default original user name
+    // defaultNameFemale_jp: "[ジータ]",
+    // defaultNameMale_en: "[Gran]",
+    // defaultNameFemale_en: "[Djeeta]",
+    defaultName: "[플레이어]", // Default original user name
+    // defaultTransNameMale: "[그랑]", // Default translated user name
+    // defaultTransNameFemale: "[지타]",
     defaultFont: "src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-04@2.1/InfinitySans-RegularA1.woff') format('woff'); font-weight: normal; font-style: normal;",
     defaultFontName: "NanumSquare"
 };
@@ -30,6 +31,7 @@ var imageBlobsUrl = [];
 var battleJson = false;
 var kCheck = /[ㄱ-ㅎ|ㅏ-ㅣ|가-힣]/; // regeexp for finding Korean (source: http://blog.daum.net/osban/14691815)
 var kCheckSpecial = /[\{\}\[\]\/?.,;:～：|\)*~`!^\-_+<>@\#$%&\\\=\(\'\"]/gi; // regex for removing special characters
+var jCheck = /[一-龠]+|[ぁ-ゔ]+|[ァ-ヴー]/;
 
 var extractedSceneCode = '';
 var skipSceneCode = '';
@@ -42,79 +44,12 @@ var dbDef = {
     dbUpgradeNeeded: false,
     //dbVer 값은 소수점 불가. 정수값만 가능. 
     //이 값은 개발자가 임의로 사용자의 DB를 강제로 삭제하고 새로운 DB로 업그레이드하게 하고싶을때 값을 올림.
-    dbVer: 2 //만약 이 값을 올렸다면 반드시 script() 함수 내에도 있는 dbDef 객체도 맞춰서 수정해주기바람!!!
+    dbVer: 3 //만약 이 값을 올렸다면 반드시 script() 함수 내에도 있는 dbDef 객체도 맞춰서 수정해주기바람!!!
 }
-var dbNextUpdateTime = null;
+var dbNextUpdateTime_text = null;
+var dbNextUpdateTime_image = null;
 var dbReUpdate = false;
 var userName = '';
-
-// Coversation with popup window
-// chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
-//     if (request.data == 'updateDBTexts') {
-//         updateDBTexts();
-//     }
-//     if (request.data == 'updateDBImages') {
-//         updateDBImages();
-//     }
-//     if (request.data == 'resetDB') {
-//         resetDB();
-//     }
-//     if (request.data == 'clearScenes') {
-//         sceneFullInfo = [];
-//         chrome.storage.local.set({
-//             sceneFullInfo: sceneFullInfo
-//         });
-//         window.location.reload();
-//     }
-//     if (request.data == 'clearBattle') {
-//         battleFullInfo = [];
-//         chrome.storage.local.set({
-//             battleFullInfo: battleFullInfo
-//         });
-//         window.location.reload();
-//     }
-//     if (request.data == 'update') {
-//         if (skipTranslatedText)
-//             RemoveTranslatedText();
-//         chrome.storage.local.set({
-//             sceneFullInfo: sceneFullInfo,
-//             battleFullInfo: battleFullInfo,
-//             nTEXT: cNames,
-//             mTEXT: miscs
-//         });
-//         if (!doc.URL.includes('play_view')) {
-//             chrome.storage.local.set({
-//                 sceneCodeFull: 0,
-//                 sceneCodeStatus: 0
-//             });
-//         }
-//     }
-//     if (request.data == 'clearName') {
-//         cNames = [];
-//         chrome.storage.local.set({
-//             nTEXT: cNames
-//         });
-//     }
-//     if (request.data == 'clearMisc') {
-//         miscs = [];
-//         chrome.storage.local.set({
-//             mTEXT: miscs
-//         });
-//     }
-//     if (request.data == 'refresh') {
-//         sceneFullInfo = [];
-//         battleFullInfo = [];
-//         cNames = [];
-//         miscs = [];
-//         chrome.storage.local.set({
-//             sceneFullInfo: sceneFullInfo,
-//             battleFullInfo: battleFullInfo,
-//             nTEXT: cNames,
-//             mTEXT: miscs
-//         });
-//         window.location.reload();
-//     }
-// });
 
 //The options object must set at least one of 'attributes', 'characterData', or 'childList' to true.
 var config = {
@@ -123,7 +58,7 @@ var config = {
     subtree: true,
     characterData: true
 };
-var config_tutorial = {
+var config_full = {
     attributes: true,
     childList: true,
     subtree: true,
@@ -187,6 +122,7 @@ function getUserName() {
     }
     return resultUserName;
 }
+
 //스토리 재생 페이지에서만 작동됨.
 //계정 처음 생성하고 유저 네임이 없을때 적용하기위한 함수.
 function getDefaultUserName() {
@@ -213,16 +149,21 @@ function getDefaultUserName() {
     return resultUserName;
 }
 
+
 function getTransDefaultUserName(text) {
     var transDefaultUserName = '';
 
-    if (text.includes('グラン') || text.includes('Gran')) {
+    if (text && text.includes('グラン') || text.includes('Gran')) {
         transDefaultUserName = '그랑';
-    } else if (text.includes('ジータ') || text.includes('Djeeta')) {
+    } else if (text && text.includes('ジータ') || text.includes('Djeeta')) {
         transDefaultUserName = '지타';
+    } else {
+        transDefaultUserName = text;
     }
+
     return transDefaultUserName;
 }
+
 
 function walkDownTree(node, command, variable = null) {
     if (node.innerHTML || node.className.includes('btn-')) command(node, variable);
@@ -259,7 +200,7 @@ function walkDownTree(node, command, variable = null) {
 }
 
 function walkDownTreeSrc(node, command, variable = null) {
-    if (node.className) {
+    if (node && node.className) {
         if (
             !node.length &&
             !node.className.includes('item') && // it's too much.
@@ -268,7 +209,7 @@ function walkDownTreeSrc(node, command, variable = null) {
             command(node, variable);
         }
     }
-    if (!node.className) {
+    if (node && !node.className) {
         // in case of list of nodes
         if (node.id) {
             if (node.length) {
@@ -288,7 +229,7 @@ function walkDownTreeSrc(node, command, variable = null) {
             }
         }
     } else {
-        if (node.hasChildNodes()) {
+        if (node && node.hasChildNodes()) {
             for (var i = 0; i < node.childElementCount; i++)
                 walkDownTreeSrc(node.children[i], command, variable);
         }
@@ -296,13 +237,13 @@ function walkDownTreeSrc(node, command, variable = null) {
 }
 
 function walkDownTreeStyle(node, command, variable = null) {
-    if (!node.childElementCount) {
+    if (node && !node.childElementCount) {
         command(node, variable);
     }
-    if (!node.length) {
+    if (node && !node.length) {
         command(node, variable);
     }
-    if (!node.className) {
+    if (node && !node.className) {
         // in case of list of nodes
         if (node.id) {
             if (node.length) {
@@ -322,7 +263,7 @@ function walkDownTreeStyle(node, command, variable = null) {
             }
         }
     } else {
-        if (node.hasChildNodes()) {
+        if (node && node.hasChildNodes()) {
             for (var i = 0; i < node.childElementCount; i++)
                 walkDownTreeStyle(node.children[i], command, variable);
         }
@@ -1535,15 +1476,15 @@ var createDB = async function () {
             imageJson,
             battleJson,
             imageBlobs,
-            dbNextUpdateTime
+            dbNextUpdateTime_text,
+            dbNextUpdateTime_image
         });
         trx.add({
             type: 'options',
             doImageSwap,
             doBattleTrans,
             isVerboseMode,
-            transMode,
-            skipTranslatedText
+            transMode
         });
         trx.add({
             type: 'userName',
@@ -1573,7 +1514,8 @@ var getDB = async function () {
             battleJson = requestResult.battleJson;
             imageBlobs = requestResult.imageBlobs;
             imageBlobsUrl = [];
-            dbNextUpdateTime = requestResult.dbNextUpdateTime;
+            dbNextUpdateTime_text = requestResult.dbNextUpdateTime_text;
+            dbNextUpdateTime_image = requestResult.dbNextUpdateTime_image;
             imageBlobs.some(function (item) {
                 try {
                     var blobURL = URL.createObjectURL(item.kr);
@@ -1661,8 +1603,11 @@ var updateDBTexts = async function () {
     nameJson = parseCsv(await request(generalConfig.origin + '/data/name.csv'));
     archiveJson = parseCsv(await request(generalConfig.origin + '/data/archive.csv'));
     battleJson = parseCsv(await request(generalConfig.origin + '/data/battle.csv'));
-    dbNextUpdateTime = new Date();
-    dbNextUpdateTime.setHours(24, 0, 0, 0);
+    dbNextUpdateTime_text = new Date();
+    dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
+    dbNextUpdateTime_image = new Date();
+    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+
 
     return new Promise(function (resolve, reject) {
         var trx = dbDef.dbCon.transaction(dbDef.dbStoreName, "readwrite").objectStore(dbDef.dbStoreName);
@@ -1676,13 +1621,11 @@ var updateDBTexts = async function () {
                 imageJson,
                 battleJson,
                 imageBlobs,
-                dbNextUpdateTime
+                dbNextUpdateTime_text,
+                dbNextUpdateTime_image
             });
             requestUpdate.onsuccess = function (event) {
                 PrintLog('업데이트 완료');
-                chrome.runtime.sendMessage({
-                    data: "updateCompleted"
-                });
                 resolve();
             };
         }
@@ -1690,15 +1633,19 @@ var updateDBTexts = async function () {
 };
 
 var updateDBImages = async function () {
-    //image blob 읽어들이기. 대략 10초 내로 전부 불러들이는듯.
+    dbNextUpdateTime_text = new Date();
+    dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
+    dbNextUpdateTime_image = new Date();
+    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+
     imageJson = parseCsv(await request(generalConfig.origin + '/data/image.csv'));
     imageBlobs = [];
     imageBlobsUrl = [];
+    //image blob 읽어들이기. 대략 10초 내로 전부 불러들이는듯. 
     await Promise.all(imageJson.map(async (item) => {
         if (item.kr) {
             try {
-                PrintLog('image downloading');
-                PrintLog(generalConfig.imageOrigin + item.kr);
+                PrintLog(`updateDBImages - image downloading ${generalConfig.imageOrigin + item.kr}`);
                 var imgBlob = await request(generalConfig.imageOrigin + item.kr);
 
                 imageBlobs.push({
@@ -1730,13 +1677,11 @@ var updateDBImages = async function () {
                 imageJson,
                 battleJson,
                 imageBlobs,
-                dbNextUpdateTime
+                dbNextUpdateTime_text,
+                dbNextUpdateTime_image
             });
             requestUpdate.onsuccess = function (event) {
                 PrintLog('업데이트 완료');
-                chrome.runtime.sendMessage({
-                    data: "updateCompleted"
-                });
                 resolve();
             };
         }
@@ -1780,8 +1725,10 @@ async function InitList() {
         battleJson = parseCsv(await request(generalConfig.origin + '/data/battle.csv'));
         imageBlobs = [];
         imageBlobsUrl = [];
-        dbNextUpdateTime = new Date();
-        dbNextUpdateTime.setHours(24, 0, 0, 0);
+        dbNextUpdateTime_text = new Date();
+        dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
+        dbNextUpdateTime_image = new Date();
+        dbNextUpdateTime_image.setHours(24 + 5, 0, 0, 0);
         userName = '';
         //image blob 읽어들이기. 대략 10초 내로 전부 불러들이는듯.
         await Promise.all(imageJson.map(async (item) => {
@@ -1824,255 +1771,192 @@ async function InitList() {
         getDBUserName();
 
     }
-
-    //다음날 자정(0시)를 넘어가서 새로고침하면 자동으로 업데이트함.
-    var dbUpdatedTime = new Date();
-    PrintLog(`dbNextUpdateTime : ${dbNextUpdateTime}`);
-    PrintLog(`dbUpdatedTime : ${dbUpdatedTime}`);
-    PrintLog(`dbUpdatedTime > dbNextUpdateTime : ${dbNextUpdateTime <= dbUpdatedTime }`);
-    if (dbNextUpdateTime <= dbUpdatedTime) {
-        dbNextUpdateTime = new Date();
-        dbNextUpdateTime.setHours(24, 0, 0, 0);
+    /*
+        번역문 업데이트는 1시간 간격으로.
+        이미지 업데이트는 다음 날 새벽 5시에.
+    */
+    var currentTime = new Date();
+    PrintLog(`dbNextUpdateTime_text : ${dbNextUpdateTime_text}`);
+    PrintLog(`dbNextUpdateTime_image : ${dbNextUpdateTime_image}`);
+    PrintLog(`currentTime : ${currentTime}`);
+    PrintLog(`currentTime >= dbNextUpdateTime : ${currentTime >= dbNextUpdateTime_text }`);
+    PrintLog(`currentTime >= dbNextUpdateTime : ${currentTime >= dbNextUpdateTime_image }`);
+    if (dbNextUpdateTime_text <= currentTime) {
         updateDBTexts();
+        updateDBUserName(userName);
+    } else if (dbNextUpdateTime_image <= currentTime) {
         if (doImageSwap) {
             updateDBImages();
         }
-        updateDBUserName(userName);
     }
 
+    //새로고침을 업데이트 도중에해서 이미지 업데이트가 끊겼다면,
+    //imageBlobs 배열 길이를 imageJson 배열 길이로 계산하여 다시 다운로드 시작.
+    if (doImageSwap) {
+        var imageLength = 0;
+        imageJson.some(function (item) {
+            if (item.orig.length != 0 && item.orig[0] != '!') {
+                imageLength++;
+            }
+        });
+
+        PrintLog(`ImageJson Pure Length : ${imageLength}`);
+        PrintLog(`ImageBlobs Length : ${imageBlobs.length}`);
+        if (doImageSwap && imageBlobs && imageBlobs.length < imageLength) {
+            PrintLog("imageBlobs Length dosen't match with imagejson length");
+            updateDBImages();
+        }
+    }
 
     //크롬 옵션들은 매번 업데이트 해주기.
     await updateDBOptions();
 
-    async function script() {
-        var imageBlobs = [];
-        var imageBlobsUrl = [];
-        var archiveJson = [];
 
-
-        var doImageSwap = null;
-        var transMode = null;
-        var isVerboseMode = null;
-
-        function window_PrintLog(text) {
-            if (isVerboseMode) {
-                window.dispatchEvent(new CustomEvent('console_log', {
-                    detail: text
-                }));
-            }
-        }
-
-        function window_extractStoryText(text) {
-            window.dispatchEvent(new CustomEvent('extract_storyText', {
+    function window_PrintLog(text) {
+        if (isVerboseMode) {
+            window.dispatchEvent(new CustomEvent('console_log', {
                 detail: text
             }));
         }
+    }
 
-        // window.indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB ||
-        //     window.msIndexedDB;
-        // window.IDBTransaction = window.IDBTransaction || window.webkitIDBTransaction ||
-        //     window.msIDBTransaction;
-        // window.IDBKeyRange = window.IDBKeyRange ||
-        //     window.webkitIDBKeyRange || window.msIDBKeyRange
+    function window_extractStoryText(text) {
+        window.dispatchEvent(new CustomEvent('extract_storyText', {
+            detail: text
+        }));
+    }
 
-        if (!window.indexedDB) {
-            window.alert("이 브라우저는 indexedDB 기능을 지원하지 않습니다.\n\n최신 크롬 브라우저를 이용해주세요.");
-            return;
-        }
 
-        var dbDef = {
-            dbCon: null,
-            dbName: 'gbfTransKorDB',
-            dbStoreName: 'gbfTransKorStore',
-            dbUpgradeNeeded: false,
-            dbVer: 2
-        }
+    // 캔버스 이미지 번역
+    // 캔버스에서 불러오는 이미지는 확인 가능. 그러나 모든 이미지 url 을 볼 수 는없었음. 
+    // 예를들어, 메인 페이지에서는 어떠한 이미지도 밑의 함수들을 거치지 않음.
+    if (transMode && doImageSwap) {
+        Object.defineProperty(Image.prototype, 'src', {
+            get: function (url) {
+                return this.getAttribute('src')
+            },
 
-        var connectDB = async function () {
-            return new Promise(function (resolve, reject) {
-                var requestDB = window.indexedDB.open(dbDef.dbName, dbDef.dbVer);
+            set: function (url) {
+                if (url == '') {
+                    this.setAttribute('src', url);
+                    return;
+                }
+                //이미지 깨짐 현상 일어나는 페이지들에 대한 예외목록
+                if (document.URL.includes('/#gacha') ||
+                    document.URL.includes('/#mypage')) {
+                    this.setAttribute('src', url);
+                    return;
+                }
+                //공격 버튼 이미지 번역이 안되는 현상 발견됨. 전투 페이지에서도 이미지 번역 수행하도록 변경함.
+                // if (document.URL.includes('/#raid')) {
+                //     this.setAttribute('src', url);
+                //     return;
+                // }
+                window_PrintLog(`IMAGE URL LOG : ${url}`);
 
-                requestDB.onerror = function (event) {
-                    reject(event);
-                };
+                imageBlobsUrl.some(function (item) {
+                    if (item.orig) {
+                        window_PrintLog(`item.orig: ${item.orig}`);
+                        if (url.includes(item.orig) && url.includes('assets')) {
+                            window_PrintLog(`TRNASLATED IMAGE URL LOG: ${String(item.kr)}`);
 
-                requestDB.onsuccess = function (event) {
-                    dbDef.dbCon = event.target.result;
-                    resolve();
-                };
-            });
-        }
-        var getDB = async function () {
-            return new Promise(function (resolve, reject) {
-                var trx = dbDef.dbCon.transaction(dbDef.dbStoreName, "readonly").objectStore(dbDef.dbStoreName);
-                var allRecords = trx.getAll();
-                allRecords.onsuccess = function (event) {
-                    var datas = event.target.result[0];
-                    var options = event.target.result[1];
-
-                    //DATAs
-                    imageBlobs = datas.imageBlobs;
-                    imageBlobs.some(function (item) {
-                        imageBlobsUrl.push({
-                            orig: item.orig,
-                            kr: URL.createObjectURL(item.kr)
-                        });
-                    });
-
-                    archiveJson = datas.archiveJson;
-
-                    //OPTIONs
-                    doImageSwap = options.doImageSwap;
-                    doBattleTrans = options.doBattleTrans;
-                    transMode = options.transMode;
-                    isVerboseMode = options.isVerboseMode;
-
-                    resolve();
-                };
-            });
-        }
-
-        await connectDB();
-        await getDB();
-
-        // 캔버스 이미지 번역
-        // 캔버스에서 불러오는 이미지는 확인 가능. 그러나 모든 이미지 url 을 볼 수 는없었음. 
-        // 예를들어, 메인 페이지에서는 어떠한 이미지도 밑의 함수들을 거치지 않음.
-        if (transMode && doImageSwap) {
-            Object.defineProperty(Image.prototype, 'src', {
-                get: function (url) {
-                    return this.getAttribute('src')
-                },
-
-                set: function (url) {
-                    if (url == '') {
-                        this.setAttribute('src', url);
-                        return;
+                            url = item.kr;
+                            return true;
+                        }
                     }
-                    //이미지 깨짐 현상 일어나는 페이지들에 대한 예외목록
-                    if (document.URL.includes('/#gacha') ||
-                        document.URL.includes('mypage')) {
-                        this.setAttribute('src', url);
-                        return;
-                    }
-                    //전투 화면에서는 battleObserver 가 번역을 수행하고있으니 여기서는 끄기.
-                    if (document.URL.includes('/#raid')) {
-                        this.setAttribute('src', url);
-                        return;
-                    }
-                    window_PrintLog(`IMAGE URL LOG : ${url}`);
+                });
 
-                    imageBlobsUrl.some(function (item) {
-                        if (item.orig) {
-                            window_PrintLog(`item.orig: ${item.orig}`);
-                            if (String(url).includes(String(item.orig)) && String(url).includes('assets')) {
-                                // window_PrintLog(`TRNASLATED IMAGE URL LOG: ${String(item.kr)}`);
+                this.setAttribute('src', url);
+            }
+        });
+    }
 
-                                url = item.kr;
+    //캔버스 텍스트 번역 & 추출
+    if (transMode || exMode) {
+        var origCanvasRenderingContext = CanvasRenderingContext2D.prototype.fillText;
+        CanvasRenderingContext2D.prototype.fillText = function () {
+            if (arguments.length <= 1) {
+                return;
+            }
+            window_PrintLog('canvas text');
+
+            var stext = arguments[0];
+            window_PrintLog(arguments);
+
+            // If the text contains any number, save the number and replace it to "*"
+            var number = stext.replace(/[^0-9]/g, '');
+            if (number.length > 0) {
+                stext = stext.replace(/[0-9]/g, '*');
+            }
+
+            if (transMode) {
+                var transText = '';
+
+                archiveJson.some(function (item) {
+                    if (item.kr) {
+                        if (stext.length == item.orig.length) {
+                            if (stext == item.orig) {
+                                transText = item.kr;
                                 return true;
                             }
                         }
-                    });
-
-                    this.setAttribute('src', url);
-                }
-            });
-        }
-
-        //캔버스 텍스트 번역
-        if (transMode) {
-            var origCanvasRenderingContext = CanvasRenderingContext2D.prototype.fillText;
-            CanvasRenderingContext2D.prototype.fillText = function () {
-                if (arguments.length <= 1) {
-                    return;
-                }
-                window_PrintLog('canvas text');
-
-                var stext = arguments[0];
-                window_PrintLog(arguments);
-
-                // If the text contains any number, save the number and replace it to "*"
-                var number = stext.replace(/[^0-9]/g, '');
-                if (number.length > 0) {
-                    stext = stext.replace(/[0-9]/g, '*');
-                }
-
-                if (transMode) {
-                    var transText = '';
-
-                    archiveJson.some(function (item) {
-                        if (item.kr) {
-                            if (stext.length == item.orig.length) {
-                                if (String(stext) == String(item.orig)) {
-                                    transText = String(item.kr);
-                                    return true;
-                                }
+                    }
+                });
+                if (transText) {
+                    if (transText.length > 0) {
+                        if (number.length > 0) {
+                            // If it contains number("*"), recover it from the saved number
+                            for (var i = 0; i < number.length; i++) {
+                                transText = transText.slice(0, transText.indexOf('*')) + number[i] + transText.slice(transText.indexOf('*') + 1);
                             }
                         }
-                    });
-                    if (transText) {
-                        if (transText.length > 0) {
-                            if (number.length > 0) {
-                                // If it contains number("*"), recover it from the saved number
-                                for (var i = 0; i < number.length; i++) {
-                                    transText = transText.slice(0, transText.indexOf('*')) + number[i] + transText.slice(transText.indexOf('*') + 1);
-                                }
-                            }
 
-                            arguments[0] = transText;
-                        }
+                        arguments[0] = transText;
                     }
                 }
-
-                origCanvasRenderingContext.apply(this, arguments);
             }
+
+            origCanvasRenderingContext.apply(this, arguments);
         }
+    }
 
-        //스토리 번역을 위해 신코드 추출
-        if (transMode) {
-            var origOpen = window.XMLHttpRequest.prototype.open;
-            window.XMLHttpRequest.prototype.open = function () {
-                window_PrintLog('XHR OPEN');
-                window_PrintLog(arguments[1]);
+    //스토리 번역을 위해 신코드 추출
+    if (transMode) {
+        var origOpen = window.XMLHttpRequest.prototype.open;
+        window.XMLHttpRequest.prototype.open = function () {
+            window_PrintLog('XHR OPEN');
+            window_PrintLog(arguments[1]);
 
-                //신코드 추출
-                //url에 scene_list가 들어간건 신코드가 아님.
-                if (arguments[1] && !String(arguments[1]).includes('scene_list') && (String(arguments[1]).includes('/quest/cleared_quest_scenario/') || String(arguments[1]).includes('/quest/scenario/scene_'))) {
-                    //eg) http://game.granbluefantasy.jp/quest/scenario/scene_evt201208_cp1_q1_s10?
-                    var scenecode = arguments[1].slice(arguments[1].indexOf('scene_'));
-                    scenecode = scenecode.split('?')[0];
+            //신코드 추출
+            //url에 scene_list가 들어간건 신코드가 아님.
+            //신코드 추출
+            //url에 scene_list가 들어간건 신코드가 아님.
+            if (arguments[1] &&
+                !arguments[1].includes('scene_list') &&
+                (arguments[1].includes('/quest/cleared_quest_scenario/') ||
+                    arguments[1].includes('/quest/scenario/scene_') ||
+                    arguments[1].includes('/quest/scenario_archive/'))) {
+                //eg) http://game.granbluefantasy.jp/quest/scenario/scene_evt201208_cp1_q1_s10?
+                var scenecode = arguments[1].slice(arguments[1].indexOf('scene_'));
+                scenecode = scenecode.split('?')[0];
 
-                    // eg) scene_evt201208_cp1_q1_s10/null 
-                    // 이벤트 스토리에서 종종 발생.
-                    if (scenecode.includes('/')) {
-                        scenecode = scenecode.split('/')[0];
-                    }
-
-                    window_PrintLog('SceneCode : ');
-                    window_PrintLog(scenecode);
-                    window_extractStoryText({
-                        type: 'scenecode',
-                        data: scenecode
-                    });
+                // eg) scene_evt201208_cp1_q1_s10/null 
+                // 이벤트 스토리에서 종종 발생.
+                if (scenecode.includes('/')) {
+                    scenecode = scenecode.split('/')[0];
                 }
-                return origOpen.apply(this, [].slice.call(arguments));
-            };
-        }
+
+                window_PrintLog('SceneCode : ');
+                window_PrintLog(scenecode);
+                window_extractStoryText({
+                    type: 'scenecode',
+                    data: scenecode
+                });
+            }
+            return origOpen.apply(this, [].slice.call(arguments));
+        };
     }
 
-
-
-    function inject(fn) {
-        const script = document.createElement('script');
-        script.text = `(${fn.toString()})();`;
-        document.head.appendChild(script);
-        // document.documentElement.appendChild(script);
-    }
-
-    //이미지 번역 또는 전투 화면 번역이 켜져있다면 수행.
-    if ((transMode && (doImageSwap || doBattleTrans))) {
-        inject(script);
-    }
 
 
     // Main Observers
@@ -2090,37 +1974,19 @@ async function InitList() {
 function translate(stext, jsonFile) {
     // Translation part for story text
     var transText = '';
-    var transDefaultUserName = getTransDefaultUserName(stext);
-
-    PrintLog(`transDefaultUserName:${transDefaultUserName}`);
-    PrintLog(`traslate taken: ${String(stext)}`);
-
-    // Replace userName to default name.
-    if (userName.length > 0 && stext.includes(userName)) {
-        stext = stext.split(userName).join(generalConfig.defaultNameMale_jp);
-    }
+    PrintLog(`traslate taken: ${stext}`);
 
     jsonFile.some(function (item) {
         if (item.kr) {
-            if (String(stext).length == String(item.orig).length) {
-                if ((String(stext) == String(item.orig))) {
-                    PrintLog(`GET:${String(item.kr)}`);
-                    transText = String(item.kr);
+            if (stext.length == item.orig.length) {
+                if ((stext == item.orig)) {
+                    PrintLog(`GET:${item.kr}`);
+                    transText = item.kr;
 
-                    var resultUserName = userName;
-                    if (transDefaultUserName.length > 0) {
-                        resultUserName = transDefaultUserName;
+                    if (transText.includes(generalConfig.defaultName)) {
+                        var resultUserName = getTransDefaultUserName(userName);
+                        transText = transText.split(generalConfig.defaultName).join(resultUserName);
                     }
-
-                    if (transText.includes(generalConfig.defaultTransNameMale))
-                        transText = transText.split(generalConfig.defaultTransNameMale).join(resultUserName);
-                    else if (transText.includes('[그란]')) {
-                        transText = transText.split(generalConfig.defaultTransNameMale).join(resultUserName);
-                    } else if (transText.includes(generalConfig.defaultTransNameFemale))
-                        transText = transText.split(generalConfig.defaultTransNameFemale).join(resultUserName);
-                    else if (transText.includes("<span class='nickname'></span>"))
-                        transText = transText.split("<span class='nickname'></span>").join(resultUserName);
-
 
                     return true;
                 }
@@ -2143,14 +2009,12 @@ function translate_StoryText(stext, jsonFile) {
     var node = doc.getElementsByClassName('prt-log-display')[0].children;
     //check if Log Exists.
     if (!node) return '';
-    PrintLog(`translate_StoryText taken: ${String(stext)}`);
+    PrintLog(`translate_StoryText taken: ${stext}`);
 
     // Translation part for story text
     var transText = '';
-    var sex = doc.getElementsByClassName('cnt-quest-scene')[0].attributes[2].value;
     var sc = extractedSceneCode;
     var defaultUserName = getDefaultUserName();
-    var transDefaultUserName = '';
 
     if (stext.includes(defaultUserName)) {
         userName = defaultUserName;
@@ -2158,10 +2022,6 @@ function translate_StoryText(stext, jsonFile) {
 
         PrintLog(`default user name in stext ${stext}`);
         PrintLog(`default user name set ${userName}`);
-
-        transDefaultUserName = getTransDefaultUserName(defaultUserName);
-
-        PrintLog(`translated default user name ${transDefaultUserName}`);
     }
 
     if (skipSceneCode == sc)
@@ -2176,7 +2036,7 @@ function translate_StoryText(stext, jsonFile) {
                     sceneCodes = sceneCodes.split(',');
 
                     for (var i = 0; i < sceneCodes.length; i++) {
-                        if (sc == String(sceneCodes[i])) {
+                        if (sc == sceneCodes[i]) {
                             cachedSceneData.push(item);
                         }
                     }
@@ -2194,8 +2054,6 @@ function translate_StoryText(stext, jsonFile) {
         return '';
     }
 
-
-    var curLanugage = doc.title == 'Granblue Fantasy' ? 'English' : 'Japanese';
     stext = stext.replace(/(\r\n|\n|\r)/gm, '').trim();
     stext = stext.split('"').join("'");
     stext = stext.replace(/&nbsp;/g, ' ');
@@ -2205,52 +2063,10 @@ function translate_StoryText(stext, jsonFile) {
     // stext : [グラン]
     // DB의 이름과 stext의 이름이 달라서 문제 발생. 
     // 이를 해결하기위해 DB의 이름을 stext의 이름으로 맞춰줌.
-    var targetDefaultName = '';
     if (userName.length > 0) {
-        if (sex == 0) {
-            if (stext.includes(userName) || stext.includes("<span class='nickname'></span>")) {
-                if (curLanugage == 'Japanese') {
-                    stext = stext.split(userName).join(generalConfig.defaultNameMale_jp);
-                    stext = stext.split("<span class='nickname'></span>").join(generalConfig.defaultNameMale_jp);
-                    targetDefaultName = generalConfig.defaultNameMale_jp;
-                } else if (curLanugage == 'English') {
-                    stext = stext.split(userName).join(generalConfig.defaultNameMale_en);
-                    stext = stext.split("<span class='nickname'></span>").join(generalConfig.defaultNameMale_en);
-                    targetDefaultName = generalConfig.defaultNameMale_en;
-                }
-            }
-        } else if (sex == 1) {
-            if (stext.includes(userName) || stext.includes("<span class='nickname'></span>")) {
-                if (curLanugage == 'Japanese') {
-                    stext = stext.split(userName).join(generalConfig.defaultNameFemale_jp);
-                    stext = stext.split("<span class='nickname'></span>").join(generalConfig.defaultNameFemale_jp);
-                    targetDefaultName = generalConfig.defaultNameFemale_jp;
-                } else if (curLanugage == 'English') {
-                    stext = stext.split(userName).join(generalConfig.defaultNameFemale_en);
-                    stext = stext.split("<span class='nickname'></span>").join(generalConfig.defaultNameFemale_en);
-                    targetDefaultName = generalConfig.defaultNameFemale_en;
-                }
-            }
-        }
-    }
-
-    if (targetDefaultName.length > 0) {
-        for (var i = 0; i < cachedSceneData.length; i++) {
-            if (!cachedSceneData[i].Origin)
-                continue;
-            if (cachedSceneData[i].Origin.includes(generalConfig.defaultNameMale_jp)) {
-                cachedSceneData[i].Origin = cachedSceneData[i].Origin.split(generalConfig.defaultNameMale_jp).join(targetDefaultName);
-            } else if (cachedSceneData[i].Origin.includes(generalConfig.defaultNameMale_en)) {
-                cachedSceneData[i].Origin = cachedSceneData[i].Origin.split(generalConfig.defaultNameMale_en).join(targetDefaultName);
-            } else if (cachedSceneData[i].Origin.includes(generalConfig.defaultNameFemale_jp)) {
-                cachedSceneData[i].Origin = cachedSceneData[i].Origin.split(generalConfig.defaultNameFemale_jp).join(targetDefaultName);
-            } else if (cachedSceneData[i].Origin.includes(generalConfig.defaultNameFemale_en)) {
-                cachedSceneData[i].Origin = cachedSceneData[i].Origin.split(generalConfig.defaultNameFemale_en).join(targetDefaultName);
-            }
-
-            if (cachedSceneData[i].Origin.includes("<span class='nickname'>")) {
-                cachedSceneData[i].Origin = cachedSceneData[i].Origin.split("<span class='nickname'></span>").join(targetDefaultName);
-            }
+        if (stext.includes(userName) || stext.includes("<span class='nickname'></span>")) {
+            stext = stext.split(userName).join(generalConfig.defaultName);
+            stext = stext.split("<span class='nickname'></span>").join(generalConfig.defaultName);
         }
     }
 
@@ -2262,17 +2078,10 @@ function translate_StoryText(stext, jsonFile) {
                 if (cachedSceneData[i].Korean) {
                     transText = cachedSceneData[i].Korean;
 
-                    var resultUserName = userName;
-                    if (resultUserName == defaultUserName) {
-                        resultUserName = transDefaultUserName;
+                    if (transText.includes(generalConfig.defaultName)) {
+                        var resultUserName = getTransDefaultUserName(userName);
+                        transText = transText.split(generalConfig.defaultName).join(resultUserName);
                     }
-
-                    if (transText.includes(generalConfig.defaultTransNameMale))
-                        transText = transText.split(generalConfig.defaultTransNameMale).join(resultUserName);
-                    else if (transText.includes(generalConfig.defaultTransNameFemale))
-                        transText = transText.split(generalConfig.defaultTransNameFemale).join(resultUserName);
-                    else if (transText.includes("<span class='nickname'></span>"))
-                        transText = transText.split("<span class='nickname'></span>").join(resultUserName);
                     break;
                 }
             }
@@ -2337,8 +2146,8 @@ function GetTranslatedImageURL(stext, jsonFile) {
     PrintLog(`Input IMG SRC: ${stext}`);
     jsonFile.some(function (item) {
         if (item.orig) {
-            if (String(stext).includes(String(item.orig)) && String(stext).includes('assets')) {
-                PrintLog(`GET URL:${String(item.kr)}`);
+            if (stext.includes(item.orig) && stext.includes('assets')) {
+                PrintLog(`GET URL:${item.kr}`);
                 // transImg = generalConfig.origin + '/images/' + String(item.kr);
                 transImg = item.kr;
                 return true;
@@ -2362,8 +2171,8 @@ function GetTranslatedImageStyle(stext, jsonFile) {
     var transImg = '';
     jsonFile.some(function (item) {
         if (item.orig) {
-            if (String(stext).includes(String(item.orig)) && String(stext).includes('assets')) {
-                PrintLog(`GET URL:${String(item.kr)}`);
+            if (stext.includes(item.orig) && stext.includes('assets')) {
+                PrintLog(`GET URL:${item.kr}`);
                 // transImg = "url('" + generalConfig.origin + '/images/' + String(item.kr) + "')";
                 transImg = "url('" + item.kr + "')";
                 PrintLog(`Check URL: ${transImg}`);
@@ -2380,20 +2189,35 @@ function GetTranslatedImageStyle(stext, jsonFile) {
     }
 }
 
-
 function GetTranslatedText(node, csv) {
     if (node) {
         var passOrNot = true;
         var textInput = node.innerHTML.replace(/(\r\n|\n|\r)/gm, '').trim();
+
+        // supporter 페이지에서 소환석 창 클릭할 때 뜨는 화면에서
+        // "このパーティでクエストに挑戦します" 이 문구가 번역 안되는 현상에 대응하기 위해 코드 수정.
+        // prt-confirm-inner 클래스의 innerHTML 는 자식 노드들까지 포함한 텍스트를 반환함.
+        // prt-confirm-inner 클래스의 바로 아래의 첫번째 자식 노드에 텍스트가 담겨져있으므로 textContent 로 수정.
+        // 게다가 첫번째 자식 노드의 타입은 #text임. 해당 노드에 className이 없음. 
+        // 그러므로, 밑에서 node를 검사할때 className이 있는지 검사하도록 코드 수정.
+        if (node.className && node.className.includes('prt-confirm-inner')) {
+            textInput = node.childNodes[0].textContent.replace(/(\r\n|\n|\r)/gm, '').trim();
+        }
+
         var translatedText = '';
         var computedStyleCheck = window
             .getComputedStyle(node, ':after')
             .content.replace(/['"]+/g, '');
         if (computedStyleCheck && computedStyleCheck != 'none') textInput = computedStyleCheck;
 
+        if (!jCheck.test(textInput)) {
+            PrintLog(`GetTranslatedText - no japanese : ${textInput}`);
+            return;
+        }
+        // 텍스트에 한글이 있는지 체크, 만약 텍스트에 userName이 포함되있다면 번역해야 하는 문장임.
         if (kCheck.test(textInput) && !textInput.includes(userName)) return;
 
-        PrintLog(`GetTranslatedText - className: ${node.className}, text: ${textInput}`);
+        PrintLog(`GetTranslatedText - className: ${node.className && node.className}, text: ${textInput}`);
         // Filter for avoiding unnecessary computing
         if (
             textInput.includes('<div ') ||
@@ -2404,22 +2228,25 @@ function GetTranslatedText(node, csv) {
             textInput.includes('a class') ||
             isNaN(textInput) == false || // Only number
             isNaN(textInput.replace('/', '')) == false || // number / number
-            node.className.includes('txt-atk') ||
-            node.className.includes('scene-font-place') ||
-            node.className.includes('prt-pop-synopsis')
+            node.className && node.className.includes('txt-atk') ||
+            node.className && node.className.includes('scene-font-place') ||
+            node.className && node.className.includes('prt-pop-synopsis') ||
+            node.className && node.className.includes('txt-supporter-name') ||
+            node.className && node.className.includes('txt-name') ||
+            node.className && node.className.includes('txt-message')
         )
             passOrNot = false;
 
         // Add exception's exception.
         if (
-            node.className.includes('name') ||
-            node.className.includes('message') ||
-            node.className.includes('comment') ||
-            node.className.includes('effect') ||
-            node.className.includes('time') ||
-            node.className.includes('txt-withdraw-trialbatle') ||
-            node.className.includes('prt-popup-header') ||
-            node.className.includes('prt-attribute-bonus')
+            node.className && node.className.includes('name') ||
+            node.className && node.className.includes('message') ||
+            node.className && node.className.includes('comment') ||
+            node.className && node.className.includes('effect') ||
+            node.className && node.className.includes('time') ||
+            node.className && node.className.includes('txt-withdraw-trialbatle') ||
+            node.className && node.className.includes('prt-popup-header') ||
+            node.className && node.className.includes('prt-attribute-bonus')
         )
             passOrNot = true;
 
@@ -2434,7 +2261,14 @@ function GetTranslatedText(node, csv) {
             if (specialtest.length < 1)
                 return;
 
-            PrintLog(`Send:${textInput} class name: ${node.className}`);
+            if (userName.length > 0 &&
+                textInput.includes(userName) &&
+                !textInput.includes('グランブル') && //'그랑블루~~' 어쩌구 하는 텍스트에서 '그랑' 부분을 유저네임으로 인식하는 것을 방지.
+                !textInput.toLowerCase().includes('granblue')) {
+                textInput = textInput.split(userName).join(generalConfig.defaultName);
+            }
+
+            PrintLog(`Send:${textInput} class name: ${node.className && node.className}`);
             // !!! Execute Translate !!!
             if (transMode) {
                 translatedText = translate(textInput, csv);
@@ -2444,7 +2278,6 @@ function GetTranslatedText(node, csv) {
             PrintLog('traslated text: ' + translatedText);
             if (translatedText) {
                 if (translatedText.length > 0) {
-                    // When it founds the translated text
                     if (number.length > 0) {
                         // If it contains number("*"), recover it from the saved number
                         for (var i = 0; i < number.length; i++) {
@@ -2453,7 +2286,7 @@ function GetTranslatedText(node, csv) {
                     }
                     PrintLog(`Take:${translatedText}`);
                     if (computedStyleCheck && computedStyleCheck != 'none') {
-                        if (!node.className.includes('-translated')) {
+                        if (node.className && !node.className.includes('-translated')) {
                             var style = doc.createElement('style');
                             style.type = 'text/css';
                             var classNames = node.className.replace(' ', '.');
@@ -2462,7 +2295,10 @@ function GetTranslatedText(node, csv) {
                             node.className += ' ' + node.className + '-translated';
                         }
                     } else {
-                        node.innerHTML = translatedText;
+                        if (node.className && node.className.includes('prt-confirm-inner')) {
+                            node.childNodes[0].textContent = translatedText;
+                        } else if (node.innerHTML)
+                            node.innerHTML = translatedText;
                     }
                 }
             }
@@ -2685,6 +2521,7 @@ var sceneObserver = new MutationObserver(function (mutations) {
 
     });
 
+    console.log(cachedSceneData);
     //줄거리 창 번역에 어려움이 있음.
     //DB 원문에 남캐로 시작하면 소년, 여캐로 시작하면 소녀로 변화무쌍하게 입력되어있음.
     //그런 경우를 다 커버하기위해 단순히 처리함.
@@ -2696,20 +2533,12 @@ var sceneObserver = new MutationObserver(function (mutations) {
                 if (!item.Korean) {
                     return true;
                 }
-                var resultUserName = userName;
-                var defaultUserName = getDefaultUserName();
-                if (userName == defaultUserName) {
-                    resultUserName = getTransDefaultUserName(defaultUserName);
-                }
-
 
                 popSynopsisNode.innerHTML = item.Korean;
 
-                if (item.Korean.includes(generalConfig.defaultTransNameMale)) {
-                    popSynopsisNode.innerHTML = item.Korean.split(generalConfig.defaultTransNameMale).join(resultUserName);
-                    return true;
-                } else if (item.Korean.includes(generalConfig.defaultTransNameFemale)) {
-                    popSynopsisNode.innerHTML = item.Korean.split(generalConfig.defaultTransNameFemale).join(resultUserName);
+                if (item.Korean.includes(generalConfig.defaultName)) {
+                    var resultUserName = getTransDefaultUserName(userName);
+                    popSynopsisNode.innerHTML = item.Korean.split(generalConfig.defaultName).join(resultUserName);
                     return true;
                 }
             }
@@ -2726,80 +2555,130 @@ var archiveObserver = new MutationObserver(function (mutations) {
     PrintLog(userName);
 
     var newUserName = getUserName();
-    if (newUserName.length > 0 && userName != newUserName) {
+    if (newUserName && newUserName.length > 0 && userName != newUserName) {
         userName = newUserName;
-        PrintLog('USER NAME CHANGED !!');
+        PrintLog(`USER NAME CHANGED !! ===> ${userName}`);
         updateDBUserName(userName);
     }
-    // else if (newUserName.length == 0) {
-    //     var defaultUserName = getDefaultUserName();
-    //     if (defaultUserName) {
-    //         userName = getDefaultUserName();
-    //         updateDBUserName(userName);
-    //     }
-    // }
 
     PrintLog('Archive Observer Mutations :');
     PrintLog(mutations);
+
     mutations.some(mutation => {
         if (mutation.target) {
-            PrintLog(`User Name : ${userName}`);
-
-            if (mutation.target.id && mutation.target.id.includes('pop')) {
-                walkDownTree(doc.getElementById('pop'), GetTranslatedText, archiveJson);
+            if (mutation.target.className && mutation.target.className == 'lis-deck flex-active-slide') {
+                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
                 return true;
             }
-            if (mutation.target.className &&
-                !mutation.target.className.includes('txt-message') &&
-                !mutation.target.className.includes('txt-character-name')
-            ) {
-                //mutation 감지되자마자 wrapper 노드를 한번만 전체 순회하고 종료함.
-                walkDownTree(doc.getElementById('wrapper'), GetTranslatedText, archiveJson);
-                return true;
+            if (!(mutation.target.id && mutation.target.id == 'wrapper') &&
+                !(mutation.target.className && mutation.target.className.includes('contents')) &&
+                !(mutation.target.tagName && mutation.target.tagName.toLowerCase() == 'script') &&
+                !(mutation.target.tagName && mutation.target.tagName.toLowerCase() == 'img') &&
+                !(mutation.target.className && mutation.target.className == 'lis-deck') &&
+                !(mutation.target.className && mutation.target.className.includes('lis-treasure')) &&
+                !(mutation.target.className && mutation.target.className.includes('prt-treasure-slider')) &&
+                !(mutation.target.className && mutation.target.className.includes('flex-viewport')) &&
+                !(mutation.target.className && mutation.target.className.includes('cnt-treasure-footer')) &&
+                !(mutation.target.className && mutation.target.className.includes('guild-name')) &&
+                (mutation.target.innerText && mutation.target.innerText.length > 0)) {
+                walkDownTree(mutation.target, GetTranslatedText, archiveJson);
             }
         }
     });
+
+    var noticeNode = doc.getElementsByClassName('prt-log prt-log-important')[0];
+    if (noticeNode) {
+        walkDownTree(noticeNode, GetTranslatedText, archiveJson);
+    }
+
+    var footerLinkNode = doc.querySelectorAll('[class^="atx-lead-link"]');
+    if (footerLinkNode) {
+        footerLinkNode.forEach(node => {
+            walkDownTree(node, GetTranslatedText, archiveJson);
+        });
+    }
 
     ObserverArchive();
 });
 var ImageObserver = new MutationObserver(function (mutations) {
-    // PrintLog(mutations);
+    PrintLog('ImageObserver mutations');
+    PrintLog(mutations);
     ImageObserver.disconnect();
-    mutations.some(mutation => {
-        if (mutation.target) {
-            if (doImageSwap && mutation.target.className) {
-                walkDownTreeSrc(mutation.target, GetTranslatedImage, imageBlobsUrl);
 
-                //어떠한 술수를 부려도 mutation이 감지가 안되는 이미지들은 하드 코딩으로 번역.
-                var banner = doc.querySelectorAll('[class^="btn-banner"]');
-                if (banner) {
-                    banner.forEach(image => {
-                        walkDownTreeSrc(image, GetTranslatedImage, imageBlobsUrl);
-                    });
+    if (doImageSwap) {
+        mutations.some(mutation => {
+            if (mutation.target) {
+                if (!(mutation.target.id && mutation.target.id == 'wrapper') &&
+                    !(mutation.target.className && mutation.target.className.includes('contents')) &&
+                    !(mutation.target.tagName && mutation.target.tagName.toLowerCase() == 'script') &&
+                    !(mutation.target.className && mutation.target.className.includes('lis-treasure')) &&
+                    !(mutation.target.className && mutation.target.className.includes('lis-deck')) &&
+                    !(mutation.target.className && mutation.target.className.includes('cnt-treasure-footer')) &&
+                    !(mutation.target.className && mutation.target.className.includes('img-treasure')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-prev')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-next')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-viewport')) &&
+                    !(mutation.target.className && mutation.target.className.includes('prt-treasure-slider'))
+                ) {
+                    walkDownTreeSrc(mutation.target, GetTranslatedImage, imageBlobsUrl);
+                    // walkDownTreeSrc(mutation.target, GetTranslatedImage, imageBlobs);
                 }
 
-                var global_banner = doc.querySelectorAll('[class^="btn-global-banner"]');
-                if (global_banner) {
-                    global_banner.forEach(image => {
-                        walkDownTreeSrc(image, GetTranslatedImage, imageBlobsUrl);
-                    });
-                }
             }
+
+        });
+
+        //어떠한 술수를 부려도 mutation이 감지가 안되는 이미지들은 하드 코딩으로 번역.
+        var banner = doc.querySelectorAll('[class^="btn-banner"]');
+        if (banner) {
+            banner.forEach(image => {
+                walkDownTreeSrc(image, GetTranslatedImage, imageBlobsUrl);
+                // walkDownTreeSrc(mutation.target, GetTranslatedImage, imageBlobs);
+            });
         }
-    });
+
+        var global_banner = doc.querySelectorAll('[class^="btn-global-banner"]');
+        if (global_banner) {
+            global_banner.forEach(image => {
+                walkDownTreeSrc(image, GetTranslatedImage, imageBlobsUrl);
+                // walkDownTreeSrc(mutation.target, GetTranslatedImage, imageBlobs);
+            });
+        }
+    }
     ObserverImage();
 });
 var ImageObserverDIV = new MutationObserver(function (mutations) {
-    // PrintLog(mutations);
+    PrintLog('ImageObserverDIV mutations');
+    PrintLog(mutations);
     ImageObserverDIV.disconnect();
 
-    mutations.some(mutation => {
-        if (mutation.target) {
-            if (doImageSwap && mutation.target.className) {
-                walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageBlobsUrl);
+    if (doImageSwap) {
+        mutations.some(mutation => {
+            if (mutation.target) {
+                if (mutation.target.className && mutation.target.className.includes('contents')) {
+                    walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageBlobsUrl);
+                    // walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageBlobs);
+                    return true;
+                }
+                if (!(mutation.target.id && mutation.target.id == 'wrapper') &&
+                    !(mutation.target.className && mutation.target.className.includes('contents')) &&
+                    !(mutation.target.tagName && mutation.target.tagName.toLowerCase() == 'script') &&
+                    !(mutation.target.className && mutation.target.className.includes('lis-treasure')) &&
+                    !(mutation.target.className && mutation.target.className.includes('lis-deck')) &&
+                    !(mutation.target.className && mutation.target.className.includes('img-treasure')) &&
+                    !(mutation.target.className && mutation.target.className.includes('cnt-treasure-footer')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-prev')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-next')) &&
+                    !(mutation.target.className && mutation.target.className.includes('flex-viewport')) &&
+                    !(mutation.target.className && mutation.target.className.includes('prt-treasure-slider'))
+                ) {
+                    walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageBlobsUrl);
+                    // walkDownTreeStyle(mutation.target, GetTranslatedImageDIV, imageBlobs);
+                }
+
             }
-        }
-    });
+        });
+    }
     ObserverImageDIV();
 });
 
@@ -2852,7 +2731,7 @@ async function ObserveSceneText() {
     ) {
         sceneObserver.observe(oText, config);
     } else if (doc.URL.includes('tutorial')) {
-        sceneObserver.observe(oText, config_tutorial);
+        sceneObserver.observe(oText, config_full);
     } else {
         //#quest 링크로 넘어가게됐을때 게임에서 새로고침을 수행함.
         //문제는 새로고침 수행하고 #raid 페이지나 #archive 페이지로 이동할때에 새로고침을 수행하지않음.
@@ -2880,7 +2759,7 @@ async function ObserverArchive() {
     if (doc.URL.includes('#result')) {
         archiveObserver.observe(oText, config_image);
     } else {
-        archiveObserver.observe(oText, config);
+        archiveObserver.observe(oText, config_full);
     }
 }
 
@@ -2929,11 +2808,7 @@ async function ObserverImage() {
         return;
     }
 
-    if (doc.URL.includes('supporter')) {
-        ImageObserver.observe(allElements, config_simple);
-    } else {
-        ImageObserver.observe(allElements, config_image);
-    }
+    ImageObserver.observe(allElements, config_full);
 }
 async function ObserverImageDIV() {
     var allElements = doc.getElementById('wrapper');
@@ -2951,11 +2826,8 @@ async function ObserverImageDIV() {
         window.setTimeout(ObserverImageDIV, generalConfig.refreshRate);
         return;
     }
-    if (doc.URL.includes('supporter')) {
-        ImageObserverDIV.observe(allElements, config_simple);
-    } else {
-        ImageObserverDIV.observe(allElements, config_image);
-    }
+
+    ImageObserverDIV.observe(allElements, config_full);
 }
 
 window.addEventListener("console_log", function (e) {

--- a/gbfTrans_test.js
+++ b/gbfTrans_test.js
@@ -1606,7 +1606,7 @@ var updateDBTexts = async function () {
     dbNextUpdateTime_text = new Date();
     dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
     dbNextUpdateTime_image = new Date();
-    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+    dbNextUpdateTime_image.setHours(24 + 5, 0, 0, 0);
 
 
     return new Promise(function (resolve, reject) {
@@ -1636,7 +1636,7 @@ var updateDBImages = async function () {
     dbNextUpdateTime_text = new Date();
     dbNextUpdateTime_text.setHours(dbNextUpdateTime_text.getHours() + 1, 0, 0, 0);
     dbNextUpdateTime_image = new Date();
-    dbNextUpdateTime_image.setHours(5, 0, 0, 0);
+    dbNextUpdateTime_image.setHours(24 + 5, 0, 0, 0);
 
     imageJson = parseCsv(await request(generalConfig.origin + '/data/image.csv'));
     imageBlobs = [];


### PR DESCRIPTION
## 1. MutationObserver에서 노드 필터링을 하드 코딩으로 추가. 
이슈 : #60
MutationObserver 에서 번역 안해도 되는 노드들까지 트리 탐색을 하는 바람에 늦어지는 것으로 보임.
이 부분을 최대한 필터링하여 속도를 개선함.

## 2. 번역문 업데이트는 1시간 간격으로. 이미지 업데이트는 다음 날 새벽 5시.
번역문 업데이트는 성능에 제한 받지 않아보이므로 1시간 간격으로 변경함.

이미지 업데이트는 사용자가 잠에 들기전이라고 생각되는 시간인 새벽 5시 전까지 업데이트를 안함으로써 도중에 번역이 풀리는 현상을 억제함.

## 3. 이미 추출된 이름은 추출되지 않게 하기. 
이슈 : #35 
```RemoveTranslatedText``` 함수에 코드 추가. 
추출된 이름들은 nameJson을 탐색해서 중복 방지.

스토리 텍스트랑 전투 텍스트에 대한 부분은 다음 PR때 추가해보겠음.

## 4. 추출시 유저 네임을 [플레이어]로 변경. 
이슈 : #59
기존에는 추출시에 성별에따라 유저네임을 치환해줘야했고, 번역시에도 성별에따라 치환해줘야했음. 

그래서 코드가 많이 복잡해졌고 버그가 많이 있었음. 

아마도 내가 성별에 따른 유저네임 치환 과정을 적용할때부터 코드가 많이 복잡해진것같음. 

이제 추출시 [플레이어]로 변경했으니 번역시에도 [플레이어] 부분을 유저 네임으로 인식하게 하면 되서 코드도 유지보수하기 좋아진것같음.

**이 PR이 통과된다면 DB의 모든 텍스트 수정을 진행해야함.** 

**```[지타], [그랑], [グラン], [ジータ], [Gran], [Djeeta] ```  디폴트 네임들을 ```[플레이어]```로 바꾸기만 하면됨. 컨트롤+H 버튼으로 쉽게될듯.** 

**물론 님이 허락해주면 진행하겠음.** 

만약 [플레이어]로 안바꾸게된다면 번역 텍스트에는 [지타] 또는 [그랑]으로 그대로 찍혀서 나옴.

## 5. gbfTrans_test.js 수정.
탬퍼몽키 버전에서는 inject를 안해도 Object 객체 수정이 가능해서 inject를 안해도 된다고 느낌.

퍼포먼스 테스트할때는 ```initList``` 함수에서 DB 불러올때 0.25초 걸렸고, ```script``` 함수에서 DB 불러오기를 또 해서 0.18초 걸렸음. 

그래서 코드 수정을 최소한으로 하면서 inject 스크립트를 제거해봤음.

탬퍼몽키 버전에서는 inject를 안해도되니까 빼버리고 조금이라도 성능 향상을 해봄. 

근데 크롬 확장 버전이랑 속도 비교해보니까 속도 차이는 안나고 완전 똑같은것같은데 괜히 수정했나 싶기도하고.

크롬 개발자 툴에서 성능 측정해봤을땐 확실히 0.18초의 작업이 사라져서 이득이란것이 확인되긴함. 

탬퍼몽키에 맞게 코드 수정했다는것에 의의를 두기로했음. 버그가 생긴다면 기존 코드로 변경하겠음.

## 6. 전투 화면에서 공격 버튼 번역 안되는 부분 수정.
다시 확인해보니까 공격 버튼 이미지는 캔버스 이미지였음.

캔버스 이미지 번역은 전투화면에서 안하게끔 수정한 코드가 있었는데 그 부분을 주석처리해서 해결함.

전투 화면의 이미지들은 전부 BattleObserver에서 처리되는줄알아서 캔버스 이미지 번역 기능을 꺼뒀었는데 공격 버튼이 캔버스 이미지일줄은 몰랐었네 ㅈㅅ 

## 7. 사이드 스토리 배너 클릭시 뜨는 줄거리 텍스트 추출&번역 안되는 현상 해결

![1](https://user-images.githubusercontent.com/22585023/107123279-045b7e00-68e0-11eb-9d9a-07dbd8c55c4c.PNG)
![2](https://user-images.githubusercontent.com/22585023/107123281-058cab00-68e0-11eb-87a4-2c891e8c331c.PNG)

저 줄거리 텍스트가 ```GetTranslatedText``` 함수에서 

```node.className && node.className.includes('prt-pop-synopsis')``` 필터링 구간에 걸려버리는 바람에 안되는것으로 보임.

원래 의도는 줄거리 번역할때 GetTranslatedText을 거치면 일부 장소명이나 이름이 먼저 번역되버려서 원본을 훼손시키는 현상이 있어서 필터링 걸어둔 거였음. 원본 훼손 현상에 대한 부분은 다시 검토해보겠음.

여기서는 사이드 스토리 페이지에서만 필터링을 풀도록 하겠음.

```(node.className && node.className.includes('prt-pop-synopsis') && !doc.URL.includes('#sidestory'))``` 이렇게 사이드 스토리 페이지에 있으면 필터링 하지 말라는 조건을 추가해서 해결함.



## ToDo

### 1. #61 번역문 조합기능은 다음에 꼭 하겠음.
### 2. 추출 영상 만들기. 

<hr>
일단 gbfTrans_test.js랑 contest.js만 푸쉬했음. 테스트 해봤을때 문제없으면 gbfTrans.js 푸쉬하고, DB 텍스트 수정 작업도 하겠음.
